### PR TITLE
[Feat] 기업·증권사 가입 신청 승인/거절 흐름 구현(#13)

### DIFF
--- a/mkx-platform/src/main/java/com/beyond/MKX/common/auth/controller/SignUpController.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/common/auth/controller/SignUpController.java
@@ -1,0 +1,38 @@
+package com.beyond.MKX.common.auth.controller;
+
+import com.beyond.MKX.common.apiResponse.ApiResponse;
+import com.beyond.MKX.domain.admin.entity.Admin;
+import com.beyond.MKX.domain.corporation.dto.CorporationSignUpReqDto;
+import com.beyond.MKX.domain.corporation.service.CorporationService;
+import com.beyond.MKX.domain.securities_firm.dto.SecuritiesFirmSignUpReqDto;
+import com.beyond.MKX.domain.securities_firm.service.SecuritiesFirmService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth/signup")
+@RequiredArgsConstructor
+public class SignUpController {
+
+    private final CorporationService corporationService;
+    private final SecuritiesFirmService securitiesFirmService;
+
+    // 기업 회원가입
+    @PostMapping("/corporation")
+    public ResponseEntity<?> corporationSignUp(@Valid @RequestBody CorporationSignUpReqDto request) {
+        Admin admin = corporationService.signUpAdmin(request);
+        return ApiResponse.created(admin.getId(), "기업 관리자 가입 신청 완료");
+    }
+
+    // 증권사 회원가입
+    @PostMapping("/securities-firm")
+    public ResponseEntity<?> securitiesFirmSignUp(@Valid @RequestBody SecuritiesFirmSignUpReqDto request) {
+        Admin admin = securitiesFirmService.signUpAdmin(request);
+        return ApiResponse.created(admin.getId(), "증권사 관리자 가입 신청 완료");
+    }
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/common/auth/controller/SignUpController.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/common/auth/controller/SignUpController.java
@@ -8,9 +8,10 @@ import com.beyond.MKX.domain.securities_firm.dto.SecuritiesFirmSignUpReqDto;
 import com.beyond.MKX.domain.securities_firm.service.SecuritiesFirmService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,15 +24,15 @@ public class SignUpController {
     private final SecuritiesFirmService securitiesFirmService;
 
     // 기업 회원가입
-    @PostMapping("/corporation")
-    public ResponseEntity<?> corporationSignUp(@Valid @RequestBody CorporationSignUpReqDto request) {
+    @PostMapping(value = "/corporation", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> corporationSignUp(@Valid @ModelAttribute CorporationSignUpReqDto request) {
         Admin admin = corporationService.signUpAdmin(request);
         return ApiResponse.created(admin.getId(), "기업 관리자 가입 신청 완료");
     }
 
     // 증권사 회원가입
-    @PostMapping("/securities-firm")
-    public ResponseEntity<?> securitiesFirmSignUp(@Valid @RequestBody SecuritiesFirmSignUpReqDto request) {
+    @PostMapping(value = "/securities-firm", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> securitiesFirmSignUp(@Valid @ModelAttribute SecuritiesFirmSignUpReqDto request) {
         Admin admin = securitiesFirmService.signUpAdmin(request);
         return ApiResponse.created(admin.getId(), "증권사 관리자 가입 신청 완료");
     }

--- a/mkx-platform/src/main/java/com/beyond/MKX/common/auth/filter/CsrfFilter.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/common/auth/filter/CsrfFilter.java
@@ -33,10 +33,11 @@ public class CsrfFilter extends OncePerRequestFilter {
         String path = request.getRequestURI();
         String method = request.getMethod();
 
-        // 로그인/토큰/로그아웃 같은 경로는 CSRF 검증 제외
-        if (    path.startsWith("/auth/login") ||
+        // 로그인/토큰/가입 등 공개 경로는 CSRF 검증 제외
+        if (path.startsWith("/auth/login") ||
                 path.startsWith("/auth/refresh") ||
-                path.startsWith("/auth/logout")) {
+                path.startsWith("/auth/logout") ||
+                path.startsWith("/auth/signup"))  {
             filterChain.doFilter(request, response);
             return;
         }

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/controller/AdminApprovalController.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/controller/AdminApprovalController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/admin/approvals")
+@RequestMapping("/admin/approval-requests")
 @RequiredArgsConstructor
 public class AdminApprovalController {
 

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/controller/AdminApprovalController.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/controller/AdminApprovalController.java
@@ -1,0 +1,129 @@
+package com.beyond.MKX.domain.admin.controller;
+
+import com.beyond.MKX.common.apiResponse.ApiResponse;
+import com.beyond.MKX.domain.admin.dto.MySignUpStatusDto;
+import com.beyond.MKX.domain.admin.dto.RejectRequestDto;
+import com.beyond.MKX.domain.admin.entity.Role;
+import com.beyond.MKX.domain.admin.service.AdminApprovalService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/admin/approvals")
+@RequiredArgsConstructor
+public class AdminApprovalController {
+
+    private final AdminApprovalService adminApprovalService;
+
+    @GetMapping("/corporations")
+    public ResponseEntity<?> listPendingCorporations(@RequestHeader("X-User-Role") String roleHeader) {
+        requireRole(roleHeader, Role.EXCHANGE);
+        return ApiResponse.ok(
+                adminApprovalService.getPendingCorporationSummaries(),
+                "기업 가입 신청 목록 조회 성공"
+        );
+    }
+
+    @GetMapping("/corporations/{corporationId}")
+    public ResponseEntity<?> getCorporationDetail(@RequestHeader("X-User-Role") String roleHeader,
+                                                  @PathVariable UUID corporationId) {
+        requireRole(roleHeader, Role.EXCHANGE);
+        return ApiResponse.ok(
+                adminApprovalService.getCorporationDetail(corporationId),
+                "기업 가입 신청 상세 조회 성공"
+        );
+    }
+
+    @GetMapping("/securities-firms")
+    public ResponseEntity<?> listPendingSecuritiesFirms(@RequestHeader("X-User-Role") String roleHeader) {
+        requireRole(roleHeader, Role.EXCHANGE);
+        return ApiResponse.ok(
+                adminApprovalService.getPendingSecuritiesFirmSummaries(),
+                "증권사 가입 신청 목록 조회 성공"
+        );
+    }
+
+    @GetMapping("/securities-firms/{securitiesFirmId}")
+    public ResponseEntity<?> getSecuritiesFirmDetail(@RequestHeader("X-User-Role") String roleHeader,
+                                                     @PathVariable UUID securitiesFirmId) {
+        requireRole(roleHeader, Role.EXCHANGE);
+        return ApiResponse.ok(
+                adminApprovalService.getSecuritiesFirmDetail(securitiesFirmId),
+                "증권사 가입 신청 상세 조회 성공"
+        );
+    }
+
+    @PostMapping("/corporations/{corporationId}/approve")
+    public ResponseEntity<?> approveCorporation(@RequestHeader("X-User-Role") String roleHeader,
+                                                @PathVariable UUID corporationId) {
+        requireRole(roleHeader, Role.EXCHANGE);
+        adminApprovalService.approveCorporation(corporationId);
+        return ApiResponse.ok(null, "기업 가입 신청 승인 완료");
+    }
+
+    @PostMapping("/corporations/{corporationId}/reject")
+    public ResponseEntity<?> rejectCorporation(@RequestHeader("X-User-Role") String roleHeader,
+                                               @PathVariable UUID corporationId,
+                                               @Valid @RequestBody RejectRequestDto request) {
+        requireRole(roleHeader, Role.EXCHANGE);
+        adminApprovalService.rejectCorporation(corporationId, request.getReason());
+        return ApiResponse.ok(null, "기업 가입 신청 거절 완료");
+    }
+
+    @PostMapping("/securities-firms/{securitiesFirmId}/approve")
+    public ResponseEntity<?> approveSecuritiesFirm(@RequestHeader("X-User-Role") String roleHeader,
+                                                   @PathVariable UUID securitiesFirmId) {
+        requireRole(roleHeader, Role.EXCHANGE);
+        adminApprovalService.approveSecuritiesFirm(securitiesFirmId);
+        return ApiResponse.ok(null, "증권사 가입 신청 승인 완료");
+    }
+
+    @PostMapping("/securities-firms/{securitiesFirmId}/reject")
+    public ResponseEntity<?> rejectSecuritiesFirm(@RequestHeader("X-User-Role") String roleHeader,
+                                                  @PathVariable UUID securitiesFirmId,
+                                                  @Valid @RequestBody RejectRequestDto request) {
+        requireRole(roleHeader, Role.EXCHANGE);
+        adminApprovalService.rejectSecuritiesFirm(securitiesFirmId, request.getReason());
+        return ApiResponse.ok(null, "증권사 가입 신청 거절 완료");
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<?> getMyApplication(@RequestHeader("X-User-Id") String userId,
+                                              @RequestHeader("X-User-Role") String roleHeader) {
+        Role role = parseRole(roleHeader);
+        if (role != Role.CORPORATION && role != Role.BROKERAGE) {
+            throw new IllegalArgumentException("가입 신청 상태 조회 권한이 없습니다.");
+        }
+
+        UUID adminId = parseUserId(userId);
+        MySignUpStatusDto dto = adminApprovalService.getMySignUpStatus(adminId);
+        return ApiResponse.ok(dto, "내 가입 신청 상태 조회 성공");
+    }
+
+    private UUID parseUserId(String userId) {
+        try {
+            return UUID.fromString(userId);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("잘못된 사용자 ID 형식");
+        }
+    }
+
+    private void requireRole(String roleHeader, Role expected) {
+        Role role = parseRole(roleHeader);
+        if (role != expected) {
+            throw new IllegalArgumentException("요청 권한이 없습니다.");
+        }
+    }
+
+    private Role parseRole(String roleHeader) {
+        try {
+            return Role.valueOf(roleHeader.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("잘못된 사용자 역할 형식");
+        }
+    }
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/AdminSummaryDto.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/AdminSummaryDto.java
@@ -1,0 +1,28 @@
+package com.beyond.MKX.domain.admin.dto;
+
+import com.beyond.MKX.domain.admin.entity.Admin;
+import com.beyond.MKX.domain.admin.entity.Status;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+public class AdminSummaryDto {
+    private UUID adminId;
+    private String name;
+    private String email;
+    private String phone;
+    private Status status;
+
+    public static AdminSummaryDto from(Admin admin) {
+        return AdminSummaryDto.builder()
+                .adminId(admin.getId())
+                .name(admin.getName())
+                .email(admin.getEmail())
+                .phone(admin.getPhone())
+                .status(admin.getStatus())
+                .build();
+    }
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/CorporationSignUpApprovalDetailDto.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/CorporationSignUpApprovalDetailDto.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 
 @Getter
 @Builder
-public class CorporationSignUpApprovalDto {
+public class CorporationSignUpApprovalDetailDto {
 
     private UUID corporationId;
     private String nameKo;
@@ -30,8 +30,8 @@ public class CorporationSignUpApprovalDto {
     private LocalDateTime createdAt;
     private AdminSummaryDto admin;
 
-    public static CorporationSignUpApprovalDto from(Corporation corporation, AdminSummaryDto admin) {
-        return CorporationSignUpApprovalDto.builder()
+    public static CorporationSignUpApprovalDetailDto from(Corporation corporation, AdminSummaryDto admin) {
+        return CorporationSignUpApprovalDetailDto.builder()
                 .corporationId(corporation.getId())
                 .nameKo(corporation.getNameKo())
                 .nameEng(corporation.getNameEng())

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/CorporationSignUpApprovalDto.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/CorporationSignUpApprovalDto.java
@@ -1,0 +1,53 @@
+package com.beyond.MKX.domain.admin.dto;
+
+import com.beyond.MKX.domain.corporation.entity.Corporation;
+import com.beyond.MKX.domain.corporation.entity.Status;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class CorporationSignUpApprovalDto {
+
+    private UUID corporationId;
+    private String nameKo;
+    private String nameEng;
+    private String ownerName;
+    private String regNo;
+    private Status status;
+    private String rejectReason;
+    private LocalDate estDate;
+    private String roadAddress;
+    private String detailAddress;
+    private Long capital;
+    private Long recentAnnualSales;
+    private String businessRegistrationCert;
+    private String corporateSealCert;
+    private LocalDateTime createdAt;
+    private AdminSummaryDto admin;
+
+    public static CorporationSignUpApprovalDto from(Corporation corporation, AdminSummaryDto admin) {
+        return CorporationSignUpApprovalDto.builder()
+                .corporationId(corporation.getId())
+                .nameKo(corporation.getNameKo())
+                .nameEng(corporation.getNameEng())
+                .ownerName(corporation.getOwnerName())
+                .regNo(corporation.getRegNo())
+                .status(corporation.getStatus())
+                .rejectReason(corporation.getRejectReason())
+                .estDate(corporation.getEstDate())
+                .roadAddress(corporation.getRoadAddress())
+                .detailAddress(corporation.getDetailAddress())
+                .capital(corporation.getCapital())
+                .recentAnnualSales(corporation.getRecentAnnualSales())
+                .businessRegistrationCert(corporation.getBusinessRegistrationCert())
+                .corporateSealCert(corporation.getCorporateSealCert())
+                .createdAt(corporation.getCreatedAt())
+                .admin(admin)
+                .build();
+    }
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/CorporationSignUpSummaryDto.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/CorporationSignUpSummaryDto.java
@@ -1,0 +1,19 @@
+package com.beyond.MKX.domain.admin.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class CorporationSignUpSummaryDto {
+    private UUID corporationId;
+    private String nameKo;
+    private String ownerName;
+    private String regNo;
+    private LocalDateTime createdAt;
+    private String adminName;
+    private String adminEmail;
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/MySignUpStatusDto.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/MySignUpStatusDto.java
@@ -6,20 +6,20 @@ import lombok.Getter;
 @Getter
 @Builder
 public class MySignUpStatusDto {
-    private String type; // CORPORATION or SECURITIES_FIRM
-    private CorporationSignUpApprovalDto corporation;
-    private SecuritiesFirmSignUpApprovalDto securitiesFirm;
+    private SignUpType type;
+    private CorporationSignUpApprovalDetailDto corporation;
+    private SecuritiesFirmSignUpApprovalDetailDto securitiesFirm;
 
-    public static MySignUpStatusDto ofCorporation(CorporationSignUpApprovalDto corporationDto) {
+    public static MySignUpStatusDto ofCorporation(CorporationSignUpApprovalDetailDto corporationDto) {
         return MySignUpStatusDto.builder()
-                .type("CORPORATION")
+                .type(SignUpType.CORPORATION)
                 .corporation(corporationDto)
                 .build();
     }
 
-    public static MySignUpStatusDto ofSecuritiesFirm(SecuritiesFirmSignUpApprovalDto securitiesFirmDto) {
+    public static MySignUpStatusDto ofSecuritiesFirm(SecuritiesFirmSignUpApprovalDetailDto securitiesFirmDto) {
         return MySignUpStatusDto.builder()
-                .type("SECURITIES_FIRM")
+                .type(SignUpType.SECURITIES_FIRM)
                 .securitiesFirm(securitiesFirmDto)
                 .build();
     }

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/MySignUpStatusDto.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/MySignUpStatusDto.java
@@ -1,0 +1,26 @@
+package com.beyond.MKX.domain.admin.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MySignUpStatusDto {
+    private String type; // CORPORATION or SECURITIES_FIRM
+    private CorporationSignUpApprovalDto corporation;
+    private SecuritiesFirmSignUpApprovalDto securitiesFirm;
+
+    public static MySignUpStatusDto ofCorporation(CorporationSignUpApprovalDto corporationDto) {
+        return MySignUpStatusDto.builder()
+                .type("CORPORATION")
+                .corporation(corporationDto)
+                .build();
+    }
+
+    public static MySignUpStatusDto ofSecuritiesFirm(SecuritiesFirmSignUpApprovalDto securitiesFirmDto) {
+        return MySignUpStatusDto.builder()
+                .type("SECURITIES_FIRM")
+                .securitiesFirm(securitiesFirmDto)
+                .build();
+    }
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/RejectRequestDto.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/RejectRequestDto.java
@@ -1,0 +1,13 @@
+package com.beyond.MKX.domain.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class RejectRequestDto {
+
+    @NotBlank(message = "거절 사유는 필수입니다.")
+    @Size(max = 255, message = "거절 사유는 255자 이하여야 합니다.")
+    private String reason;
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/SecuritiesFirmSignUpApprovalDetailDto.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/SecuritiesFirmSignUpApprovalDetailDto.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 @Getter
 @Builder
-public class SecuritiesFirmSignUpApprovalDto {
+public class SecuritiesFirmSignUpApprovalDetailDto {
 
     private UUID securitiesFirmId;
     private String nameKo;
@@ -30,8 +30,8 @@ public class SecuritiesFirmSignUpApprovalDto {
     private LocalDateTime createdAt;
     private AdminSummaryDto admin;
 
-    public static SecuritiesFirmSignUpApprovalDto from(SecuritiesFirm firm, AdminSummaryDto admin) {
-        return SecuritiesFirmSignUpApprovalDto.builder()
+    public static SecuritiesFirmSignUpApprovalDetailDto from(SecuritiesFirm firm, AdminSummaryDto admin) {
+        return SecuritiesFirmSignUpApprovalDetailDto.builder()
                 .securitiesFirmId(firm.getId())
                 .nameKo(firm.getNameKo())
                 .nameEng(firm.getNameEng())

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/SecuritiesFirmSignUpApprovalDto.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/SecuritiesFirmSignUpApprovalDto.java
@@ -1,0 +1,54 @@
+package com.beyond.MKX.domain.admin.dto;
+
+import com.beyond.MKX.domain.securities_firm.entity.SecuritiesFirm;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class SecuritiesFirmSignUpApprovalDto {
+
+    private UUID securitiesFirmId;
+    private String nameKo;
+    private String nameEng;
+    private String ownerName;
+    private String regNo;
+    private SecuritiesFirm.Status status;
+    private String rejectReason;
+    private LocalDate establishedDate;
+    private String roadAddress;
+    private String detailAddress;
+    private String financialInvestmentLicenseNo;
+    private String financialInvestmentLicenseDoc;
+    private String businessRegistrationCert;
+    private String corporateSealCert;
+    private Double exchangeFee;
+    private LocalDateTime createdAt;
+    private AdminSummaryDto admin;
+
+    public static SecuritiesFirmSignUpApprovalDto from(SecuritiesFirm firm, AdminSummaryDto admin) {
+        return SecuritiesFirmSignUpApprovalDto.builder()
+                .securitiesFirmId(firm.getId())
+                .nameKo(firm.getNameKo())
+                .nameEng(firm.getNameEng())
+                .ownerName(firm.getOwnerName())
+                .regNo(firm.getRegNo())
+                .status(firm.getStatus())
+                .rejectReason(firm.getRejectReason())
+                .establishedDate(firm.getEstablishedDate())
+                .roadAddress(firm.getRoadAddress())
+                .detailAddress(firm.getDetailAddress())
+                .financialInvestmentLicenseNo(firm.getFinancialInvestmentLicenseNo())
+                .financialInvestmentLicenseDoc(firm.getFinancialInvestmentLicenseDoc())
+                .businessRegistrationCert(firm.getBusinessRegistrationCert())
+                .corporateSealCert(firm.getCorporateSealCert())
+                .exchangeFee(firm.getExchangeFee())
+                .createdAt(firm.getCreatedAt())
+                .admin(admin)
+                .build();
+    }
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/SecuritiesFirmSignUpSummaryDto.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/SecuritiesFirmSignUpSummaryDto.java
@@ -1,0 +1,19 @@
+package com.beyond.MKX.domain.admin.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class SecuritiesFirmSignUpSummaryDto {
+    private UUID securitiesFirmId;
+    private String nameKo;
+    private String ownerName;
+    private String regNo;
+    private LocalDateTime createdAt;
+    private String adminName;
+    private String adminEmail;
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/SignUpType.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/dto/SignUpType.java
@@ -1,0 +1,9 @@
+package com.beyond.MKX.domain.admin.dto;
+
+/**
+ * 기업/증권사 가입 신청 유형을 나타내는 전용 타입.
+ */
+public enum SignUpType {
+    CORPORATION,
+    SECURITIES_FIRM
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/entity/Admin.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/entity/Admin.java
@@ -54,4 +54,8 @@ public class Admin extends BaseIdAndTimeEntity {
     @ManyToOne
     @JoinColumn(name = "securities_firm_id")
     private SecuritiesFirm securitiesFirm;
+
+    public void changeStatus(Status status) {
+        this.status = status;
+    }
 }

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/entity/Admin.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/entity/Admin.java
@@ -1,6 +1,8 @@
 package com.beyond.MKX.domain.admin.entity;
 
 import com.beyond.MKX.common.domain.BaseIdAndTimeEntity;
+import com.beyond.MKX.domain.corporation.entity.Corporation;
+import com.beyond.MKX.domain.securities_firm.entity.SecuritiesFirm;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -40,5 +42,16 @@ public class Admin extends BaseIdAndTimeEntity {
     // 관리자 상태
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
-    private Status status;
+    @Builder.Default
+    private Status status = Status.PENDING;
+
+    // 소속 법인
+    @ManyToOne
+    @JoinColumn(name = "corporation_id")
+    private Corporation corporation;
+
+    // 소속 증권사
+    @ManyToOne
+    @JoinColumn(name = "securities_firm_id")
+    private SecuritiesFirm securitiesFirm;
 }

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/entity/Status.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/entity/Status.java
@@ -1,8 +1,9 @@
 package com.beyond.MKX.domain.admin.entity;
 
 public enum Status {
-    PENDING, // 대기
-    ACTIVE, //활성
-    SUSPENDED, //정지
-    DELETED //삭제
+    PENDING,   // 대기
+    ACTIVE,    // 활성
+    REJECTED,  // 거절
+    SUSPENDED, // 정지
+    DELETED    // 삭제
 }

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/entity/Status.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/entity/Status.java
@@ -1,6 +1,7 @@
 package com.beyond.MKX.domain.admin.entity;
 
 public enum Status {
+    PENDING, // 대기
     ACTIVE, //활성
     SUSPENDED, //정지
     DELETED //삭제

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/repository/AdminRepository.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/repository/AdminRepository.java
@@ -1,8 +1,11 @@
 package com.beyond.MKX.domain.admin.repository;
 
 import com.beyond.MKX.domain.admin.entity.Admin;
+import com.beyond.MKX.domain.corporation.entity.Corporation;
+import com.beyond.MKX.domain.securities_firm.entity.SecuritiesFirm;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
 import java.util.Optional;
 import java.util.UUID;
 
@@ -16,5 +19,11 @@ public interface AdminRepository extends JpaRepository<Admin, UUID> {
 
     // 전화번호 중복 여부 확인
     boolean existsByPhone(String phone);
+
+    // 기업 소속 관리자 조회
+    Optional<Admin> findByCorporation(Corporation corporation);
+
+    // 증권사 소속 관리자 조회
+    Optional<Admin> findBySecuritiesFirm(SecuritiesFirm securitiesFirm);
 
 }

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/repository/AdminRepository.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/repository/AdminRepository.java
@@ -3,11 +3,18 @@ package com.beyond.MKX.domain.admin.repository;
 import com.beyond.MKX.domain.admin.entity.Admin;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
 import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface AdminRepository extends JpaRepository<Admin, UUID> {
+    // 이메일 기반 관리자 조회
     Optional<Admin> findByEmail (String email);
+
+    // 동일 이메일 등록 여부 확인 (대소문자 무시)
+    boolean existsByEmailIgnoreCase(String email);
+
+    // 전화번호 중복 여부 확인
+    boolean existsByPhone(String phone);
+
 }

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/service/AdminApprovalService.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/service/AdminApprovalService.java
@@ -46,26 +46,26 @@ public class AdminApprovalService {
 
     @Transactional(readOnly = true)
     // EXCHANGE 상세 조회 - 기업 신청 + 대표 관리자 정보 포함 반환
-    public CorporationSignUpApprovalDto getCorporationDetail(UUID corporationId) {
+    public CorporationSignUpApprovalDetailDto getCorporationDetail(UUID corporationId) {
         Corporation corporation = corporationRepository.findById(corporationId)
                 .orElseThrow(() -> new EntityNotFoundException("기업 신청을 찾을 수 없습니다."));
 
         Admin admin = adminRepository.findByCorporation(corporation)
                 .orElseThrow(() -> new EntityNotFoundException("기업 관리자 정보를 찾을 수 없습니다."));
 
-        return CorporationSignUpApprovalDto.from(corporation, AdminSummaryDto.from(admin));
+        return CorporationSignUpApprovalDetailDto.from(corporation, AdminSummaryDto.from(admin));
     }
 
     @Transactional(readOnly = true)
     // EXCHANGE 상세 조회 - 증권사 신청 + 대표 관리자 정보 포함 반환
-    public SecuritiesFirmSignUpApprovalDto getSecuritiesFirmDetail(UUID securitiesFirmId) {
+    public SecuritiesFirmSignUpApprovalDetailDto getSecuritiesFirmDetail(UUID securitiesFirmId) {
         SecuritiesFirm firm = securitiesFirmRepository.findById(securitiesFirmId)
                 .orElseThrow(() -> new EntityNotFoundException("증권사 신청을 찾을 수 없습니다."));
 
         Admin admin = adminRepository.findBySecuritiesFirm(firm)
                 .orElseThrow(() -> new EntityNotFoundException("증권사 관리자 정보를 찾을 수 없습니다."));
 
-        return SecuritiesFirmSignUpApprovalDto.from(firm, AdminSummaryDto.from(admin));
+        return SecuritiesFirmSignUpApprovalDetailDto.from(firm, AdminSummaryDto.from(admin));
     }
 
     @Transactional(readOnly = true)
@@ -77,14 +77,14 @@ public class AdminApprovalService {
         if (admin.getCorporation() != null) {
             Corporation corporation = admin.getCorporation();
             return MySignUpStatusDto.ofCorporation(
-                    CorporationSignUpApprovalDto.from(corporation, AdminSummaryDto.from(admin))
+                    CorporationSignUpApprovalDetailDto.from(corporation, AdminSummaryDto.from(admin))
             );
         }
 
         if (admin.getSecuritiesFirm() != null) {
             SecuritiesFirm firm = admin.getSecuritiesFirm();
             return MySignUpStatusDto.ofSecuritiesFirm(
-                    SecuritiesFirmSignUpApprovalDto.from(firm, AdminSummaryDto.from(admin))
+                    SecuritiesFirmSignUpApprovalDetailDto.from(firm, AdminSummaryDto.from(admin))
             );
         }
 

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/service/AdminApprovalService.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/service/AdminApprovalService.java
@@ -1,0 +1,189 @@
+package com.beyond.MKX.domain.admin.service;
+
+import com.beyond.MKX.domain.admin.dto.*;
+import com.beyond.MKX.domain.admin.entity.Admin;
+import com.beyond.MKX.domain.admin.entity.Status;
+import com.beyond.MKX.domain.admin.repository.AdminRepository;
+import com.beyond.MKX.domain.corporation.entity.Corporation;
+import com.beyond.MKX.domain.corporation.repository.CorporationRepository;
+import com.beyond.MKX.domain.securities_firm.entity.SecuritiesFirm;
+import com.beyond.MKX.domain.securities_firm.repository.SecuritiesFirmRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminApprovalService {
+
+    private final CorporationRepository corporationRepository;
+    private final SecuritiesFirmRepository securitiesFirmRepository;
+    private final AdminRepository adminRepository;
+
+    @Transactional(readOnly = true)
+    // EXCHANGE 목록용 - PENDING 상태의 기업 신청 요약 목록 반환
+    public List<CorporationSignUpSummaryDto> getPendingCorporationSummaries() {
+        return corporationRepository.findAllByStatus(com.beyond.MKX.domain.corporation.entity.Status.PENDING)
+                .stream()
+                .map(this::toCorporationSummary)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    // EXCHANGE 목록용 - PENDING 상태의 증권사 신청 요약 목록 반환
+    public List<SecuritiesFirmSignUpSummaryDto> getPendingSecuritiesFirmSummaries() {
+        return securitiesFirmRepository.findAllByStatus(SecuritiesFirm.Status.PENDING)
+                .stream()
+                .map(this::toSecuritiesFirmSummary)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    // EXCHANGE 상세 조회 - 기업 신청 + 대표 관리자 정보 포함 반환
+    public CorporationSignUpApprovalDto getCorporationDetail(UUID corporationId) {
+        Corporation corporation = corporationRepository.findById(corporationId)
+                .orElseThrow(() -> new EntityNotFoundException("기업 신청을 찾을 수 없습니다."));
+
+        Admin admin = adminRepository.findByCorporation(corporation)
+                .orElseThrow(() -> new EntityNotFoundException("기업 관리자 정보를 찾을 수 없습니다."));
+
+        return CorporationSignUpApprovalDto.from(corporation, AdminSummaryDto.from(admin));
+    }
+
+    @Transactional(readOnly = true)
+    // EXCHANGE 상세 조회 - 증권사 신청 + 대표 관리자 정보 포함 반환
+    public SecuritiesFirmSignUpApprovalDto getSecuritiesFirmDetail(UUID securitiesFirmId) {
+        SecuritiesFirm firm = securitiesFirmRepository.findById(securitiesFirmId)
+                .orElseThrow(() -> new EntityNotFoundException("증권사 신청을 찾을 수 없습니다."));
+
+        Admin admin = adminRepository.findBySecuritiesFirm(firm)
+                .orElseThrow(() -> new EntityNotFoundException("증권사 관리자 정보를 찾을 수 없습니다."));
+
+        return SecuritiesFirmSignUpApprovalDto.from(firm, AdminSummaryDto.from(admin));
+    }
+
+    @Transactional(readOnly = true)
+    // 대표 관리자 전용 - 자신의 신청 현황(기업 혹은 증권사)을 상세 DTO로 반환
+    public MySignUpStatusDto getMySignUpStatus(UUID adminId) {
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(() -> new EntityNotFoundException("관리자를 찾을 수 없습니다."));
+
+        if (admin.getCorporation() != null) {
+            Corporation corporation = admin.getCorporation();
+            return MySignUpStatusDto.ofCorporation(
+                    CorporationSignUpApprovalDto.from(corporation, AdminSummaryDto.from(admin))
+            );
+        }
+
+        if (admin.getSecuritiesFirm() != null) {
+            SecuritiesFirm firm = admin.getSecuritiesFirm();
+            return MySignUpStatusDto.ofSecuritiesFirm(
+                    SecuritiesFirmSignUpApprovalDto.from(firm, AdminSummaryDto.from(admin))
+            );
+        }
+
+        throw new IllegalStateException("가입 신청 정보가 존재하지 않습니다.");
+    }
+
+    // 기업 신청 승인 처리: 기업/대표 관리자 상태를 ACTIVE 로 전환
+    public void approveCorporation(UUID corporationId) {
+        Corporation corporation = corporationRepository.findById(corporationId)
+                .orElseThrow(() -> new EntityNotFoundException("기업 신청을 찾을 수 없습니다."));
+
+        if (corporation.getStatus() != com.beyond.MKX.domain.corporation.entity.Status.PENDING) {
+            throw new IllegalStateException("이미 처리된 기업 신청입니다.");
+        }
+
+        Admin admin = adminRepository.findByCorporation(corporation)
+                .orElseThrow(() -> new EntityNotFoundException("기업 관리자 정보를 찾을 수 없습니다."));
+
+        corporation.approve();
+        admin.changeStatus(Status.ACTIVE);
+    }
+
+    // 기업 신청 거절 처리: 거절 사유 저장 후 기업/대표 관리자 상태를 REJECTED 로 전환
+    public void rejectCorporation(UUID corporationId, String reason) {
+        Corporation corporation = corporationRepository.findById(corporationId)
+                .orElseThrow(() -> new EntityNotFoundException("기업 신청을 찾을 수 없습니다."));
+
+        if (corporation.getStatus() != com.beyond.MKX.domain.corporation.entity.Status.PENDING) {
+            throw new IllegalStateException("이미 처리된 기업 신청입니다.");
+        }
+
+        Admin admin = adminRepository.findByCorporation(corporation)
+                .orElseThrow(() -> new EntityNotFoundException("기업 관리자 정보를 찾을 수 없습니다."));
+
+        corporation.reject(reason);
+        admin.changeStatus(Status.REJECTED);
+    }
+
+    // 증권사 신청 승인 처리: 증권사/대표 관리자 상태를 ACTIVE 로 전환
+    public void approveSecuritiesFirm(UUID securitiesFirmId) {
+        SecuritiesFirm firm = securitiesFirmRepository.findById(securitiesFirmId)
+                .orElseThrow(() -> new EntityNotFoundException("증권사 신청을 찾을 수 없습니다."));
+
+        if (firm.getStatus() != SecuritiesFirm.Status.PENDING) {
+            throw new IllegalStateException("이미 처리된 증권사 신청입니다.");
+        }
+
+        Admin admin = adminRepository.findBySecuritiesFirm(firm)
+                .orElseThrow(() -> new EntityNotFoundException("증권사 관리자 정보를 찾을 수 없습니다."));
+
+        firm.approve();
+        admin.changeStatus(Status.ACTIVE);
+    }
+
+    // 증권사 신청 거절 처리: 거절 사유 저장 후 증권사/대표 관리자 상태를 REJECTED 로 전환
+    public void rejectSecuritiesFirm(UUID securitiesFirmId, String reason) {
+        SecuritiesFirm firm = securitiesFirmRepository.findById(securitiesFirmId)
+                .orElseThrow(() -> new EntityNotFoundException("증권사 신청을 찾을 수 없습니다."));
+
+        if (firm.getStatus() != SecuritiesFirm.Status.PENDING) {
+            throw new IllegalStateException("이미 처리된 증권사 신청입니다.");
+        }
+
+        Admin admin = adminRepository.findBySecuritiesFirm(firm)
+                .orElseThrow(() -> new EntityNotFoundException("증권사 관리자 정보를 찾을 수 없습니다."));
+
+        firm.reject(reason);
+        admin.changeStatus(Status.REJECTED);
+    }
+
+    // 기업 신청 엔티티를 목록 응답용 요약 DTO로 변환
+    private CorporationSignUpSummaryDto toCorporationSummary(Corporation corporation) {
+        Admin admin = adminRepository.findByCorporation(corporation)
+                .orElseThrow(() -> new EntityNotFoundException("기업 관리자 정보를 찾을 수 없습니다."));
+
+        return CorporationSignUpSummaryDto.builder()
+                .corporationId(corporation.getId())
+                .nameKo(corporation.getNameKo())
+                .ownerName(corporation.getOwnerName())
+                .regNo(corporation.getRegNo())
+                .createdAt(corporation.getCreatedAt())
+                .adminName(admin.getName())
+                .adminEmail(admin.getEmail())
+                .build();
+    }
+
+    // 증권사 신청 엔티티를 목록 응답용 요약 DTO로 변환
+    private SecuritiesFirmSignUpSummaryDto toSecuritiesFirmSummary(SecuritiesFirm firm) {
+        Admin admin = adminRepository.findBySecuritiesFirm(firm)
+                .orElseThrow(() -> new EntityNotFoundException("증권사 관리자 정보를 찾을 수 없습니다."));
+
+        return SecuritiesFirmSignUpSummaryDto.builder()
+                .securitiesFirmId(firm.getId())
+                .nameKo(firm.getNameKo())
+                .ownerName(firm.getOwnerName())
+                .regNo(firm.getRegNo())
+                .createdAt(firm.getCreatedAt())
+                .adminName(admin.getName())
+                .adminEmail(admin.getEmail())
+                .build();
+    }
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/service/AdminSignUpService.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/admin/service/AdminSignUpService.java
@@ -1,0 +1,55 @@
+package com.beyond.MKX.domain.admin.service;
+
+import com.beyond.MKX.common.exception.DuplicateResourceException;
+import com.beyond.MKX.domain.admin.entity.Admin;
+import com.beyond.MKX.domain.admin.entity.Role;
+import com.beyond.MKX.domain.admin.entity.Status;
+import com.beyond.MKX.domain.admin.repository.AdminRepository;
+import com.beyond.MKX.domain.corporation.entity.Corporation;
+import com.beyond.MKX.domain.securities_firm.entity.SecuritiesFirm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminSignUpService {
+
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public Admin createPendingAdmin(String email,
+                                    String phone,
+                                    String name,
+                                    String rawPassword,
+                                    Role role,
+                                    Corporation corporation,
+                                    SecuritiesFirm securitiesFirm) {
+
+        validateDuplicate(email, phone);
+
+        Admin admin = Admin.builder()
+                .email(email.toLowerCase())
+                .phone(phone)
+                .name(name)
+                .password(passwordEncoder.encode(rawPassword))
+                .role(role)
+                .status(Status.PENDING)
+                .corporation(corporation)
+                .securitiesFirm(securitiesFirm)
+                .build();
+
+        return adminRepository.save(admin);
+    }
+
+    // 이메일 전화번호 검증 로직
+    private void validateDuplicate(String email, String phone) {
+        if (adminRepository.existsByEmailIgnoreCase(email)) {
+            throw new DuplicateResourceException("이미 등록된 관리자 이메일입니다.");
+        }
+
+        if (adminRepository.existsByPhone(phone)) {
+            throw new DuplicateResourceException("이미 등록된 관리자 전화번호입니다.");
+        }
+    }
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/corporation/dto/CorporationSignUpReqDto.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/corporation/dto/CorporationSignUpReqDto.java
@@ -7,10 +7,13 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class CorporationSignUpReqDto {
 
@@ -49,13 +52,11 @@ public class CorporationSignUpReqDto {
     @Positive(message = "연매출은 양수여야 합니다.")
     private Long recentAnnualSales;
 
-    @NotBlank(message = "사업자등록증 URL은 필수입니다.")
-    @Size(max = 512, message = "사업자등록증 URL은 512자 이하여야 합니다.")
-    private String businessRegistrationCert;
+    @NotNull(message = "사업자등록증 파일은 필수입니다.")
+    private MultipartFile businessRegistrationCertFile;
 
-    @NotBlank(message = "법인인감증명서 URL은 필수입니다.")
-    @Size(max = 512, message = "법인인감증명서 URL은 512자 이하여야 합니다.")
-    private String corporateSealCert;
+    @NotNull(message = "법인인감증명서 파일은 필수입니다.")
+    private MultipartFile corporateSealCertFile;
 
     @NotBlank(message = "관리자 이름은 필수입니다.")
     @Size(max = 10, message = "관리자 이름은 10자 이하여야 합니다.")

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/corporation/dto/CorporationSignUpReqDto.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/corporation/dto/CorporationSignUpReqDto.java
@@ -1,0 +1,76 @@
+package com.beyond.MKX.domain.corporation.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class CorporationSignUpReqDto {
+
+    @NotBlank(message = "기업 국문명은 필수입니다.")
+    @Size(max = 50, message = "기업 국문명은 50자 이하여야 합니다.")
+    private String nameKo;
+
+    @NotBlank(message = "기업 영문명은 필수입니다.")
+    @Size(max = 100, message = "기업 영문명은 100자 이하여야 합니다.")
+    private String nameEng;
+
+    @NotBlank(message = "대표자명은 필수입니다.")
+    @Size(max = 10, message = "대표자명은 10자 이하여야 합니다.")
+    private String ownerName;
+
+    @NotBlank(message = "사업자등록번호는 필수입니다.")
+    @Size(max = 30, message = "사업자등록번호는 30자 이하여야 합니다.")
+    private String regNo;
+
+    @NotNull(message = "설립일은 필수입니다.")
+    private LocalDate estDate;
+
+    @NotBlank(message = "도로명주소는 필수입니다.")
+    @Size(max = 50, message = "도로명주소는 50자 이하여야 합니다.")
+    private String roadAddress;
+
+    @NotBlank(message = "상세주소는 필수입니다.")
+    @Size(max = 50, message = "상세주소는 50자 이하여야 합니다.")
+    private String detailAddress;
+
+    @NotNull(message = "자본금은 필수입니다.")
+    @Positive(message = "자본금은 양수여야 합니다.")
+    private Long capital;
+
+    @NotNull(message = "연매출은 필수입니다.")
+    @Positive(message = "연매출은 양수여야 합니다.")
+    private Long recentAnnualSales;
+
+    @NotBlank(message = "사업자등록증 URL은 필수입니다.")
+    @Size(max = 512, message = "사업자등록증 URL은 512자 이하여야 합니다.")
+    private String businessRegistrationCert;
+
+    @NotBlank(message = "법인인감증명서 URL은 필수입니다.")
+    @Size(max = 512, message = "법인인감증명서 URL은 512자 이하여야 합니다.")
+    private String corporateSealCert;
+
+    @NotBlank(message = "관리자 이름은 필수입니다.")
+    @Size(max = 10, message = "관리자 이름은 10자 이하여야 합니다.")
+    private String adminName;
+
+    @NotBlank(message = "관리자 이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    @Size(max = 50, message = "관리자 이메일은 50자 이하여야 합니다.")
+    private String adminEmail;
+
+    @NotBlank(message = "관리자 전화번호는 필수입니다.")
+    @Size(max = 20, message = "관리자 전화번호는 20자 이하여야 합니다.")
+    private String adminPhone;
+
+    @NotBlank(message = "관리자 비밀번호는 필수입니다.")
+    @Size(min = 8, max = 20, message = "관리자 비밀번호는 8자 이상 20자 이하여야 합니다.")
+    private String adminPassword;
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/corporation/entity/Corporation.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/corporation/entity/Corporation.java
@@ -1,0 +1,65 @@
+package com.beyond.MKX.domain.corporation.entity;
+
+import com.beyond.MKX.common.domain.BaseIdAndTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "corporation")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Corporation extends BaseIdAndTimeEntity {
+
+    // 기업명 국문
+    @Column(nullable = false, length = 50)
+    private String nameKo;
+
+    // 기업명 영문
+    @Column(nullable = false, length = 100)
+    private String nameEng;
+
+    // 대표자명
+    @Column(nullable = false, length = 10)
+    private String ownerName;
+
+    // 사업자등록번호
+    @Column(nullable = false, length = 30, unique = true)
+    private String regNo;
+
+    // 기업 상태
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private Status status = Status.PENDING; // PENDING, ACTIVE, DELISTED
+
+    // 설립일
+    @Column(nullable = false)
+    private LocalDate estDate;
+
+    // 도로명주소
+    @Column(nullable = false, length = 50)
+    private String roadAddress;
+
+    // 상세주소
+    @Column(nullable = false, length = 50)
+    private String detailAddress;
+
+    // 자본금
+    @Column(nullable = false)
+    private Long capital;
+
+    // 최근 연매출
+    @Column(nullable = false)
+    private Long recentAnnualSales;
+
+    // 사업자등록증 url
+    @Column(nullable = false, length = 512)
+    private String businessRegistrationCert;
+
+    // 법인인감증명서 url
+    @Column(nullable = false, length = 512)
+    private String corporateSealCert;
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/corporation/entity/Corporation.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/corporation/entity/Corporation.java
@@ -33,7 +33,7 @@ public class Corporation extends BaseIdAndTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @Builder.Default
-    private Status status = Status.PENDING; // PENDING, ACTIVE, DELISTED
+    private Status status = Status.PENDING; // PENDING, ACTIVE, REJECTED, DELISTED
 
     // 설립일
     @Column(nullable = false)
@@ -62,4 +62,18 @@ public class Corporation extends BaseIdAndTimeEntity {
     // 법인인감증명서 url
     @Column(nullable = false, length = 512)
     private String corporateSealCert;
+
+    // 가입 거절 사유
+    @Column(length = 255)
+    private String rejectReason;
+
+    public void approve() {
+        this.status = Status.ACTIVE;
+        this.rejectReason = null;
+    }
+
+    public void reject(String reason) {
+        this.status = Status.REJECTED;
+        this.rejectReason = reason;
+    }
 }

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/corporation/entity/Status.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/corporation/entity/Status.java
@@ -1,0 +1,8 @@
+package com.beyond.MKX.domain.corporation.entity;
+
+public enum Status {
+    ACTIVE,
+    PENDING,
+    DELISTED
+
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/corporation/entity/Status.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/corporation/entity/Status.java
@@ -1,8 +1,8 @@
 package com.beyond.MKX.domain.corporation.entity;
 
 public enum Status {
-    ACTIVE,
     PENDING,
+    ACTIVE,
+    REJECTED,
     DELISTED
-
 }

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/corporation/repository/CorporationRepository.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/corporation/repository/CorporationRepository.java
@@ -1,0 +1,13 @@
+package com.beyond.MKX.domain.corporation.repository;
+
+import com.beyond.MKX.domain.corporation.entity.Corporation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface CorporationRepository extends JpaRepository<Corporation, UUID> {
+    // 사업자등록번호 중복 여부 검증
+    boolean existsByRegNo(String regNo);
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/corporation/repository/CorporationRepository.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/corporation/repository/CorporationRepository.java
@@ -1,13 +1,18 @@
 package com.beyond.MKX.domain.corporation.repository;
 
 import com.beyond.MKX.domain.corporation.entity.Corporation;
+import com.beyond.MKX.domain.corporation.entity.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface CorporationRepository extends JpaRepository<Corporation, UUID> {
     // 사업자등록번호 중복 여부 검증
     boolean existsByRegNo(String regNo);
+
+    // 상태별 기업 목록 조회
+    List<Corporation> findAllByStatus(Status status);
 }

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/corporation/service/CorporationService.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/corporation/service/CorporationService.java
@@ -1,6 +1,7 @@
 package com.beyond.MKX.domain.corporation.service;
 
 import com.beyond.MKX.common.exception.DuplicateResourceException;
+import com.beyond.MKX.common.s3.S3Manager;
 import com.beyond.MKX.domain.admin.entity.Admin;
 import com.beyond.MKX.domain.admin.entity.Role;
 import com.beyond.MKX.domain.admin.service.AdminSignUpService;
@@ -11,6 +12,7 @@ import com.beyond.MKX.domain.corporation.repository.CorporationRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -19,10 +21,17 @@ public class CorporationService {
 
     private final CorporationRepository corporationRepository;
     private final AdminSignUpService adminSignUpService;
+    private final S3Manager s3Manager;
 
 
     public Admin signUpAdmin(CorporationSignUpReqDto request) {
         validateDuplicateRegNo(request.getRegNo());
+
+        String businessRegistrationCertUrl = uploadOrThrow(request.getBusinessRegistrationCertFile(),
+                "corporations/business-registration");
+
+        String corporateSealCertUrl = uploadOrThrow(request.getCorporateSealCertFile(),
+                "corporations/corporate-seal");
 
         Corporation corporation = Corporation.builder()
                 .nameKo(request.getNameKo())
@@ -35,8 +44,8 @@ public class CorporationService {
                 .detailAddress(request.getDetailAddress())
                 .capital(request.getCapital())
                 .recentAnnualSales(request.getRecentAnnualSales())
-                .businessRegistrationCert(request.getBusinessRegistrationCert())
-                .corporateSealCert(request.getCorporateSealCert())
+                .businessRegistrationCert(businessRegistrationCertUrl)
+                .corporateSealCert(corporateSealCertUrl)
                 .build();
 
         Corporation savedCorporation = corporationRepository.save(corporation);
@@ -56,5 +65,13 @@ public class CorporationService {
         if (corporationRepository.existsByRegNo(regNo)) {
             throw new DuplicateResourceException("이미 등록된 사업자등록번호입니다.");
         }
+    }
+
+    private String uploadOrThrow(MultipartFile file, String prefix) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("필수 서류 파일이 비어 있습니다.");
+        }
+
+        return s3Manager.upload(file, prefix);
     }
 }

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/corporation/service/CorporationService.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/corporation/service/CorporationService.java
@@ -1,0 +1,60 @@
+package com.beyond.MKX.domain.corporation.service;
+
+import com.beyond.MKX.common.exception.DuplicateResourceException;
+import com.beyond.MKX.domain.admin.entity.Admin;
+import com.beyond.MKX.domain.admin.entity.Role;
+import com.beyond.MKX.domain.admin.service.AdminSignUpService;
+import com.beyond.MKX.domain.corporation.dto.CorporationSignUpReqDto;
+import com.beyond.MKX.domain.corporation.entity.Corporation;
+import com.beyond.MKX.domain.corporation.entity.Status;
+import com.beyond.MKX.domain.corporation.repository.CorporationRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CorporationService {
+
+    private final CorporationRepository corporationRepository;
+    private final AdminSignUpService adminSignUpService;
+
+
+    public Admin signUpAdmin(CorporationSignUpReqDto request) {
+        validateDuplicateRegNo(request.getRegNo());
+
+        Corporation corporation = Corporation.builder()
+                .nameKo(request.getNameKo())
+                .nameEng(request.getNameEng())
+                .ownerName(request.getOwnerName())
+                .regNo(request.getRegNo())
+                .status(Status.PENDING)
+                .estDate(request.getEstDate())
+                .roadAddress(request.getRoadAddress())
+                .detailAddress(request.getDetailAddress())
+                .capital(request.getCapital())
+                .recentAnnualSales(request.getRecentAnnualSales())
+                .businessRegistrationCert(request.getBusinessRegistrationCert())
+                .corporateSealCert(request.getCorporateSealCert())
+                .build();
+
+        Corporation savedCorporation = corporationRepository.save(corporation);
+
+        return adminSignUpService.createPendingAdmin(
+                request.getAdminEmail(),
+                request.getAdminPhone(),
+                request.getAdminName(),
+                request.getAdminPassword(),
+                Role.CORPORATION,
+                savedCorporation,
+                null
+        );
+    }
+
+    private void validateDuplicateRegNo(String regNo) {
+        if (corporationRepository.existsByRegNo(regNo)) {
+            throw new DuplicateResourceException("이미 등록된 사업자등록번호입니다.");
+        }
+    }
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/securities_firm/dto/SecuritiesFirmSignUpReqDto.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/securities_firm/dto/SecuritiesFirmSignUpReqDto.java
@@ -1,0 +1,78 @@
+package com.beyond.MKX.domain.securities_firm.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class SecuritiesFirmSignUpReqDto {
+
+    @NotBlank(message = "증권사 국문명은 필수입니다.")
+    @Size(max = 50, message = "증권사 국문명은 50자 이하여야 합니다.")
+    private String nameKo;
+
+    @NotBlank(message = "증권사 영문명은 필수입니다.")
+    @Size(max = 100, message = "증권사 영문명은 100자 이하여야 합니다.")
+    private String nameEng;
+
+    @NotBlank(message = "대표자명은 필수입니다.")
+    @Size(max = 10, message = "대표자명은 10자 이하여야 합니다.")
+    private String ownerName;
+
+    @NotBlank(message = "사업자등록번호는 필수입니다.")
+    @Size(max = 30, message = "사업자등록번호는 30자 이하여야 합니다.")
+    private String regNo;
+
+    @NotNull(message = "설립일은 필수입니다.")
+    private LocalDate establishedDate;
+
+    @NotBlank(message = "도로명주소는 필수입니다.")
+    @Size(max = 50, message = "도로명주소는 50자 이하여야 합니다.")
+    private String roadAddress;
+
+    @NotBlank(message = "상세주소는 필수입니다.")
+    @Size(max = 50, message = "상세주소는 50자 이하여야 합니다.")
+    private String detailAddress;
+
+    @NotBlank(message = "금융투자업 인가번호는 필수입니다.")
+    @Size(max = 50, message = "금융투자업 인가번호는 50자 이하여야 합니다.")
+    private String financialInvestmentLicenseNo;
+
+    @NotBlank(message = "금융투자업 인가증 URL은 필수입니다.")
+    @Size(max = 512, message = "금융투자업 인가증 URL은 512자 이하여야 합니다.")
+    private String financialInvestmentLicenseDoc;
+
+    @NotBlank(message = "사업자등록증 URL은 필수입니다.")
+    @Size(max = 512, message = "사업자등록증 URL은 512자 이하여야 합니다.")
+    private String businessRegistrationCert;
+
+    @NotBlank(message = "법인인감증명서 URL은 필수입니다.")
+    @Size(max = 512, message = "법인인감증명서 URL은 512자 이하여야 합니다.")
+    private String corporateSealCert;
+
+    @NotNull(message = "거래소 수수료율은 필수입니다.")
+    private Double exchangeFee;
+
+    @NotBlank(message = "관리자 이름은 필수입니다.")
+    @Size(max = 10, message = "관리자 이름은 10자 이하여야 합니다.")
+    private String adminName;
+
+    @NotBlank(message = "관리자 이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    @Size(max = 50, message = "관리자 이메일은 50자 이하여야 합니다.")
+    private String adminEmail;
+
+    @NotBlank(message = "관리자 전화번호는 필수입니다.")
+    @Size(max = 20, message = "관리자 전화번호는 20자 이하여야 합니다.")
+    private String adminPhone;
+
+    @NotBlank(message = "관리자 비밀번호는 필수입니다.")
+    @Size(min = 8, max = 20, message = "관리자 비밀번호는 8자 이상 20자 이하여야 합니다.")
+    private String adminPassword;
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/securities_firm/dto/SecuritiesFirmSignUpReqDto.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/securities_firm/dto/SecuritiesFirmSignUpReqDto.java
@@ -6,10 +6,13 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class SecuritiesFirmSignUpReqDto {
 
@@ -44,17 +47,14 @@ public class SecuritiesFirmSignUpReqDto {
     @Size(max = 50, message = "금융투자업 인가번호는 50자 이하여야 합니다.")
     private String financialInvestmentLicenseNo;
 
-    @NotBlank(message = "금융투자업 인가증 URL은 필수입니다.")
-    @Size(max = 512, message = "금융투자업 인가증 URL은 512자 이하여야 합니다.")
-    private String financialInvestmentLicenseDoc;
+    @NotNull(message = "금융투자업 인가증 파일은 필수입니다.")
+    private MultipartFile financialInvestmentLicenseDocFile;
 
-    @NotBlank(message = "사업자등록증 URL은 필수입니다.")
-    @Size(max = 512, message = "사업자등록증 URL은 512자 이하여야 합니다.")
-    private String businessRegistrationCert;
+    @NotNull(message = "사업자등록증 파일은 필수입니다.")
+    private MultipartFile businessRegistrationCertFile;
 
-    @NotBlank(message = "법인인감증명서 URL은 필수입니다.")
-    @Size(max = 512, message = "법인인감증명서 URL은 512자 이하여야 합니다.")
-    private String corporateSealCert;
+    @NotNull(message = "법인인감증명서 파일은 필수입니다.")
+    private MultipartFile corporateSealCertFile;
 
     @NotNull(message = "거래소 수수료율은 필수입니다.")
     private Double exchangeFee;

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/securities_firm/entity/SecuritiesFirm.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/securities_firm/entity/SecuritiesFirm.java
@@ -1,0 +1,76 @@
+package com.beyond.MKX.domain.securities_firm.entity;
+
+
+
+import com.beyond.MKX.common.domain.BaseIdAndTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "securities_firm")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SecuritiesFirm extends BaseIdAndTimeEntity {
+
+    // 증권사명 국문
+    @Column(nullable = false, length = 50)
+    private String nameKo;
+
+    // 증권사명 영문
+    @Column(nullable = false, length = 100)
+    private String nameEng;
+
+    // 대표자명
+    @Column(nullable = false, length = 10)
+    private String ownerName;
+
+    // 사업자등록번호
+    @Column(nullable = false, length = 30, unique = true)
+    private String regNo;
+
+    // 증권사 상태
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private Status status = Status.PENDING; // PENDING, ACTIVE, DELISTED
+
+    // 설립일
+    @Column(nullable = false)
+    private LocalDate establishedDate;
+
+    // 도로명주소
+    @Column(nullable = false, length = 50)
+    private String roadAddress;
+
+    // 상세주소
+    @Column(nullable = false, length = 50)
+    private String detailAddress;
+
+    // 금융투자업 인가번호
+    @Column(nullable = false, length = 50)
+    private String financialInvestmentLicenseNo;
+
+    // 금융투자업 인가증 url
+    @Column(nullable = false, length = 512)
+    private String financialInvestmentLicenseDoc;
+
+    // 사업자등록증 url
+    @Column(nullable = false, length = 512)
+    private String businessRegistrationCert;
+
+    // 법인인감증명서 url
+    @Column(nullable = false, length = 512)
+    private String corporateSealCert;
+
+    // 거래소 수수료율
+    @Column(nullable = false)
+    private Double exchangeFee;
+
+    public enum Status {
+        PENDING, ACTIVE, DELISTED
+    }
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/securities_firm/entity/SecuritiesFirm.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/securities_firm/entity/SecuritiesFirm.java
@@ -36,7 +36,7 @@ public class SecuritiesFirm extends BaseIdAndTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @Builder.Default
-    private Status status = Status.PENDING; // PENDING, ACTIVE, DELISTED
+    private Status status = Status.PENDING; // PENDING, ACTIVE, REJECTED, DELISTED
 
     // 설립일
     @Column(nullable = false)
@@ -70,7 +70,21 @@ public class SecuritiesFirm extends BaseIdAndTimeEntity {
     @Column(nullable = false)
     private Double exchangeFee;
 
+    // 가입 거절 사유
+    @Column(length = 255)
+    private String rejectReason;
+
     public enum Status {
-        PENDING, ACTIVE, DELISTED
+        PENDING, ACTIVE, REJECTED, DELISTED
+    }
+
+    public void approve() {
+        this.status = Status.ACTIVE;
+        this.rejectReason = null;
+    }
+
+    public void reject(String reason) {
+        this.status = Status.REJECTED;
+        this.rejectReason = reason;
     }
 }

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/securities_firm/repository/SecuritiesFirmRepository.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/securities_firm/repository/SecuritiesFirmRepository.java
@@ -1,0 +1,14 @@
+package com.beyond.MKX.domain.securities_firm.repository;
+
+import com.beyond.MKX.domain.securities_firm.entity.SecuritiesFirm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface SecuritiesFirmRepository extends JpaRepository<SecuritiesFirm, UUID> {
+    // 사업자등록번호 중복 여부 검증
+    boolean existsByRegNo(String regNo);
+
+    // 금융투자업 인가번호 중복 여부 검증
+    boolean existsByFinancialInvestmentLicenseNo(String financialInvestmentLicenseNo);
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/securities_firm/repository/SecuritiesFirmRepository.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/securities_firm/repository/SecuritiesFirmRepository.java
@@ -2,13 +2,19 @@ package com.beyond.MKX.domain.securities_firm.repository;
 
 import com.beyond.MKX.domain.securities_firm.entity.SecuritiesFirm;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
+@Repository
 public interface SecuritiesFirmRepository extends JpaRepository<SecuritiesFirm, UUID> {
     // 사업자등록번호 중복 여부 검증
     boolean existsByRegNo(String regNo);
 
     // 금융투자업 인가번호 중복 여부 검증
     boolean existsByFinancialInvestmentLicenseNo(String financialInvestmentLicenseNo);
+
+    // 상태별 증권사 목록 조회
+    List<SecuritiesFirm> findAllByStatus(SecuritiesFirm.Status status);
 }

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/securities_firm/service/SecuritiesFirmService.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/securities_firm/service/SecuritiesFirmService.java
@@ -1,6 +1,7 @@
 package com.beyond.MKX.domain.securities_firm.service;
 
 import com.beyond.MKX.common.exception.DuplicateResourceException;
+import com.beyond.MKX.common.s3.S3Manager;
 import com.beyond.MKX.domain.admin.entity.Admin;
 import com.beyond.MKX.domain.admin.entity.Role;
 import com.beyond.MKX.domain.admin.service.AdminSignUpService;
@@ -11,6 +12,7 @@ import com.beyond.MKX.domain.securities_firm.repository.SecuritiesFirmRepository
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -18,10 +20,26 @@ public class SecuritiesFirmService {
 
     private final SecuritiesFirmRepository securitiesFirmRepository;
     private final AdminSignUpService adminSignUpService;
+    private final S3Manager s3Manager;
 
     @Transactional
     public Admin signUpAdmin(SecuritiesFirmSignUpReqDto request) {
         validateDuplicate(request);
+
+        String financialInvestmentLicenseDocUrl = uploadOrThrow(
+                request.getFinancialInvestmentLicenseDocFile(),
+                "securities-firms/license"
+        );
+
+        String businessRegistrationCertUrl = uploadOrThrow(
+                request.getBusinessRegistrationCertFile(),
+                "securities-firms/business-registration"
+        );
+
+        String corporateSealCertUrl = uploadOrThrow(
+                request.getCorporateSealCertFile(),
+                "securities-firms/corporate-seal"
+        );
 
         SecuritiesFirm securitiesFirm = SecuritiesFirm.builder()
                 .nameKo(request.getNameKo())
@@ -33,9 +51,9 @@ public class SecuritiesFirmService {
                 .roadAddress(request.getRoadAddress())
                 .detailAddress(request.getDetailAddress())
                 .financialInvestmentLicenseNo(request.getFinancialInvestmentLicenseNo())
-                .financialInvestmentLicenseDoc(request.getFinancialInvestmentLicenseDoc())
-                .businessRegistrationCert(request.getBusinessRegistrationCert())
-                .corporateSealCert(request.getCorporateSealCert())
+                .financialInvestmentLicenseDoc(financialInvestmentLicenseDocUrl)
+                .businessRegistrationCert(businessRegistrationCertUrl)
+                .corporateSealCert(corporateSealCertUrl)
                 .exchangeFee(request.getExchangeFee())
                 .build();
 
@@ -60,5 +78,13 @@ public class SecuritiesFirmService {
         if (securitiesFirmRepository.existsByFinancialInvestmentLicenseNo(request.getFinancialInvestmentLicenseNo())) {
             throw new DuplicateResourceException("이미 등록된 금융투자업 인가번호입니다.");
         }
+    }
+
+    private String uploadOrThrow(MultipartFile file, String prefix) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("필수 서류 파일이 비어 있습니다.");
+        }
+
+        return s3Manager.upload(file, prefix);
     }
 }

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/securities_firm/service/SecuritiesFirmService.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/securities_firm/service/SecuritiesFirmService.java
@@ -1,0 +1,64 @@
+package com.beyond.MKX.domain.securities_firm.service;
+
+import com.beyond.MKX.common.exception.DuplicateResourceException;
+import com.beyond.MKX.domain.admin.entity.Admin;
+import com.beyond.MKX.domain.admin.entity.Role;
+import com.beyond.MKX.domain.admin.service.AdminSignUpService;
+import com.beyond.MKX.domain.securities_firm.dto.SecuritiesFirmSignUpReqDto;
+import com.beyond.MKX.domain.securities_firm.entity.SecuritiesFirm;
+import com.beyond.MKX.domain.securities_firm.entity.SecuritiesFirm.Status;
+import com.beyond.MKX.domain.securities_firm.repository.SecuritiesFirmRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SecuritiesFirmService {
+
+    private final SecuritiesFirmRepository securitiesFirmRepository;
+    private final AdminSignUpService adminSignUpService;
+
+    @Transactional
+    public Admin signUpAdmin(SecuritiesFirmSignUpReqDto request) {
+        validateDuplicate(request);
+
+        SecuritiesFirm securitiesFirm = SecuritiesFirm.builder()
+                .nameKo(request.getNameKo())
+                .nameEng(request.getNameEng())
+                .ownerName(request.getOwnerName())
+                .regNo(request.getRegNo())
+                .status(Status.PENDING)
+                .establishedDate(request.getEstablishedDate())
+                .roadAddress(request.getRoadAddress())
+                .detailAddress(request.getDetailAddress())
+                .financialInvestmentLicenseNo(request.getFinancialInvestmentLicenseNo())
+                .financialInvestmentLicenseDoc(request.getFinancialInvestmentLicenseDoc())
+                .businessRegistrationCert(request.getBusinessRegistrationCert())
+                .corporateSealCert(request.getCorporateSealCert())
+                .exchangeFee(request.getExchangeFee())
+                .build();
+
+        SecuritiesFirm savedFirm = securitiesFirmRepository.save(securitiesFirm);
+
+        return adminSignUpService.createPendingAdmin(
+                request.getAdminEmail(),
+                request.getAdminPhone(),
+                request.getAdminName(),
+                request.getAdminPassword(),
+                Role.BROKERAGE,
+                null,
+                savedFirm
+        );
+    }
+
+    private void validateDuplicate(SecuritiesFirmSignUpReqDto request) {
+        if (securitiesFirmRepository.existsByRegNo(request.getRegNo())) {
+            throw new DuplicateResourceException("이미 등록된 사업자등록번호입니다.");
+        }
+
+        if (securitiesFirmRepository.existsByFinancialInvestmentLicenseNo(request.getFinancialInvestmentLicenseNo())) {
+            throw new DuplicateResourceException("이미 등록된 금융투자업 인가번호입니다.");
+        }
+    }
+}


### PR DESCRIPTION
 ## 📋 작업 개요
  기업·증권사 가입 신청을 파일 업로드 기반으로 받아 승인/거절 흐름을 구현했습니다.
  <br/>

  ## 🔧 작업 상세

  - 기업/증권사 가입 DTO를 multipart/form-data로 전환하고, 필수 서류 파일을 S3에 업로드한 뒤 URL을 저장하도록 서비스 로직 수정
  - Admin 엔티티에 기업·증권사 연관관계 및 상태 전환 메서드(changeStatus) 추가, 공통 가입 서비스로 중복 검증·비밀번호 암호화 통합
  - 기업/증권사 엔티티에 rejectReason·approve()/reject() 추가하여 승인/거절 상태 추적
  - EXCHANGE 전용 승인 컨트롤러·서비스 구성(목록/상세/승인/거절)과 요약/상세 DTO 작성, 대표 관리자(/admin/approvals/me) 전용 조회 API 구현
  - X-User-Role, X-User-Id 헤더 검증으로 역할별 접근을 제한하고, 예외 시 공통 예외 포맷으로 응답
  <br/>

  ## 📌 이슈 번호
close #13 
  <br/>

  ## 🧪 테스트 결과
기업 목록 조회화면입니다
<img width="825" height="571" alt="image" src="https://github.com/user-attachments/assets/f642a4de-ad6c-4c74-a949-bab26efe95c0" />

증권사 목록조회입니다.
<img width="869" height="557" alt="image" src="https://github.com/user-attachments/assets/547266de-03ce-4c63-8dc3-a0db2dfd07a4" />

기업 및 증권사 가입 요청 허가 후 , PENDING  -> ACTIVE
기업 및 증권사 가입 요청 거절 후 , PENDING  -> REJECTED
<img width="885" height="483" alt="image" src="https://github.com/user-attachments/assets/2656f4ac-a380-42a1-a485-5c6ff6ef9918" />

기업 및 관리자는 가입 신청 상태 조회 가능 
<img width="853" height="629" alt="image" src="https://github.com/user-attachments/assets/b4f3f446-c196-4626-91fb-163edfbefeec" />


  <br/>

  ## ⚠️ 참고사항

  - reject_reason 컬럼 및 REJECTED enum 값이 DB에 반영되어야 합니다.
  - Postman 등 클라이언트에서 CSRF 토큰 및 X-User-Role 헤더를 반드시 포함해야 승인 API 호출이 성공합니다.
  <br/>

  ## 👥 리뷰어 지정
  @solidify-d  @jinnn12  
  <br/>

  ## ✅ PR Checklist

  - [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  - [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.
  - [x] 코드에 대한 테스트를 진행 하였으며, 결과에 대한 자료를 첨부하였습니다.
  - [x] 최소 2명의 리뷰어를 지정했습니다.