### PR TITLE
[Fix] 부분/완전 체결 후 남은 주문 적재 시 Kafka 메시지 가격을 실제 주문가로 발행 (#42)

### DIFF
--- a/matching-engine/src/main/java/com/beyond/MKX/infrastructure/kafka/KafkaOrderProducer.java
+++ b/matching-engine/src/main/java/com/beyond/MKX/infrastructure/kafka/KafkaOrderProducer.java
@@ -14,10 +14,10 @@ import java.util.UUID;
 /**
  * 매칭 엔진 결과/상태/에러를 카프카로 발행하는 프로듀서.
  *
- * 설계 요점
- * - 토픽: executions(체결), order-status(상태), order-errors(문자열 에러)
- * - 파티션 키: 종목(ticker) 또는 주문ID를 사용해 순서 일관성 유지
- * - KafkaTemplate<String, Object>: JSON 직렬화 사용(이벤트 POJO를 값으로 전송)
+ * 표준화 원칙
+ * - order-status 이벤트의 표시가격(price)은 "지정가 주문 입력값(=limitPrice)"로 고정한다.
+ *   - 부분/완전 체결에서도 price는 vwap/last가 아니라 limitPrice를 사용한다.
+ *   - 체결 관련 보조지표는 lastFillPrice, limitPrice 필드로만 제공한다.
  */
 @Component("kafkaOrderProducer")
 @RequiredArgsConstructor
@@ -36,14 +36,14 @@ public class KafkaOrderProducer {
     // ---------------------------------------------------------------------
     public void sendExecution(String marketOrderId, String ticker, String side,
                               String counterOrderId, BigDecimal qty, long price) {
-        String execId = marketOrderId + "-" + counterOrderId + "-" + UUID.randomUUID(); // 멱등키
+        String execId = marketOrderId + "-" + counterOrderId + "-" + UUID.randomUUID(); // 멱등키(충분히 유일)
         ExecutionEvent evt = ExecutionEvent.builder()
                 .execId(execId)
                 .marketOrderId(marketOrderId)
                 .counterOrderId(counterOrderId)
                 .ticker(ticker)
                 .side(side)
-                .price(price)
+                .price(price)          // 개별 체결의 실제 체결가
                 .quantity(qty)
                 .timestamp(Instant.now().toEpochMilli())
                 .build();
@@ -98,7 +98,11 @@ public class KafkaOrderProducer {
         sendOrderStatus(ticker != null ? ticker : marketOrderId, evt);
     }
 
-    /** 부분 체결(대표가격=vwap, 보조=last/limit, 누적 체결수량 포함) */
+    /**
+     * 부분 체결 알림
+     * - 표시가격(price)은 '지정가(limitPrice)'로 고정한다. (요구사항: 로그/컨슈머에서 주문 입력가 그대로 보이도록)
+     * - 체결 관련 보조지표는 lastFillPrice/limitPrice로만 제공한다.
+     */
     public void sendMarketPartial(String orderId, String ticker, String side,
                                   BigDecimal remaining,
                                   long vwap, long lastPrice, long limitPrice, BigDecimal filledQty) {
@@ -108,7 +112,7 @@ public class KafkaOrderProducer {
                 .side(side)
                 .status("MARKET_PARTIAL")
                 .remaining(remaining)
-                .price(vwap)
+                .price(limitPrice)
                 .lastFillPrice(lastPrice)
                 .limitPrice(limitPrice)
                 .filledQuantity(filledQty)
@@ -117,7 +121,10 @@ public class KafkaOrderProducer {
         sendOrderStatus(ticker != null ? ticker : orderId, evt);
     }
 
-    /** 완전 체결(대표가격=vwap, last/limit/누적 체결수량 포함) */
+    /**
+     * 완전 체결 알림
+     * - 표시가격(price)은 '지정가(limitPrice)'로 고정한다.
+     */
     public void sendMarketFilled(String orderId, String ticker, String side,
                                  long vwap, long lastPrice, long limitPrice, BigDecimal filledQty) {
         OrderStatusEvent evt = OrderStatusEvent.builder()
@@ -125,7 +132,7 @@ public class KafkaOrderProducer {
                 .ticker(ticker)
                 .side(side)
                 .status("MARKET_FILLED")
-                .price(vwap)
+                .price(limitPrice)
                 .lastFillPrice(lastPrice)
                 .limitPrice(limitPrice)
                 .filledQuantity(filledQty)


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
MatchingEngine에서 부분/완전 체결 시 Kafka 발행 메시지의 price를 VWAP/Last가 아닌 ‘실제 체결가(Execution Price)’로 일원화하였다.

<br/>

## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- 가격 산출 로직 정정
  - OrderStatus/Execution 이벤트 생성 시 price를 VWAP/Last 계산값이 아닌 실제 체결가로 매핑
  - 이후 부분 체결 누적 중에도 각 발행 시점의 실제 체결가 사용
  - 부분 체결 이후 대기 적재 할 시에는 초기 주문 가격으로 카프카 메시지 발행(기존은 VWAP 사용)

<br/>

## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #42 

<br/>

## 🧪 테스트 결과
<!-- 코드 검증 시 진행한 테스트 결과에 대한 캡쳐 이미지나 영상 혹은 기타 자료를 첨부해주세요. -->
<!-- 어떤 방식으로 테스트를 진행 하였으며, 왜 그 방식을 채택 했는지에 대한 설명도 작성해주세요. -->
<!-- 성능 테스트 방식이 잘못 되었거나 누락 되어있다면 PR은 거절됩니다. -->
- 수정 전
<img width="1628" height="130" alt="image" src="https://github.com/user-attachments/assets/befb1d8d-d565-42dd-b632-67415fc523f2" />
부분 체결 후 지정가 주문이 Redis orderBook 내에 적재 될 때 price가 주문 가격이 아닌 VWAP 가격인 1500원으로 카프카 메시지 발행하고 있는 모습. (실제 오더북 적재는 주문 가격으로 정상 적재)

- 수정 후
<img width="1563" height="120" alt="image" src="https://github.com/user-attachments/assets/c8509883-cc90-4a7e-8902-c8faa6e45031" />
부분 체결 후 지정가 주문이 Redis orderBook 내에 적재 될 때 price가 주문 가격인 500원으로 정상적으로 카프카 메시지 발행(redis 내 로직은 수정 X. orderBook 내에서는 기존에서 주문 가격으로 적재 되고 있었으나 카프카 메시지 발행 시에만 VWAP 기준으로 발행이 되었음)

<br/>

## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
없습니다.

<br/>

## 👥 리뷰어 지정
<!-- 반드시 2명 이상 리뷰어를 지정해주세요 -->
<!-- 모든 리뷰어가 PR 리뷰를 마친 뒤 병합을 진행합니다. -->
<!-- 예: @username1 @username2 -->
@jinnn12 @AstroJini 

<br/>

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: Feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.
- [x] 코드에 대한 테스트를 진행 하였으며, 결과에 대한 자료를 첨부하였습니다.
- [x] 최소 2명의 리뷰어를 지정했습니다.