### PR TITLE
[Feat] 포럼 카테고리 관련 API 및 로직 구현 (#46)

### DIFF
--- a/apigateway/src/main/java/com/beyond/MKX/common/auth/filter/JwtAuthFilter.java
+++ b/apigateway/src/main/java/com/beyond/MKX/common/auth/filter/JwtAuthFilter.java
@@ -77,7 +77,7 @@ public class JwtAuthFilter implements GlobalFilter, Ordered {
             "/ordering-service",
             "/matching-engine-service",
             "/market-data-service",
-            "community-service"
+            "/community-service"
     );
 
     public JwtAuthFilter(@Value("${jwt.secretKeyAt}") String secretKeyAtValue) {

--- a/community/src/main/java/com/beyond/MKX/common/domain/BaseTimeEntity.java
+++ b/community/src/main/java/com/beyond/MKX/common/domain/BaseTimeEntity.java
@@ -7,18 +7,22 @@ import jakarta.persistence.PreUpdate;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 @MappedSuperclass
 @Getter
 public abstract class BaseTimeEntity {
 //    RDB에 UTC vs KST로 저장할 지 의논해야 됨.
-//    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
+    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
 
-    @Column(updatable = false, nullable = false)
+    @Column(name = "created_at", updatable = false, nullable = false)
     protected LocalDateTime createdAt;
 
-    @Column(nullable = false)
+    @Column(name = "updated_at", nullable = false)
     protected LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    protected LocalDateTime deletedAt;
 
     @PrePersist
     protected void onCreate() {
@@ -29,5 +33,20 @@ public abstract class BaseTimeEntity {
     @PreUpdate
     protected void onUpdate() {
         this.updatedAt = LocalDateTime.now();
+    }
+
+    /** 소프트 삭제 처리 */
+    public void markDeleted() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    /** 소프트 삭제 복구 */
+    public void restore() {
+        this.deletedAt = null;
+    }
+
+    /** 삭제 여부 확인 */
+    public boolean isDeleted() {
+        return this.deletedAt != null;
     }
 }

--- a/community/src/main/java/com/beyond/MKX/domain/forumCategory/controller/ForumCategoryCommandController.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumCategory/controller/ForumCategoryCommandController.java
@@ -1,0 +1,50 @@
+package com.beyond.MKX.domain.forumCategory.controller;
+
+import com.beyond.MKX.common.apiResponse.ApiResponse;
+import com.beyond.MKX.domain.forumCategory.dto.ForumCategoryCreateReqDto;
+import com.beyond.MKX.domain.forumCategory.dto.ForumCategoryResDto;
+import com.beyond.MKX.domain.forumCategory.dto.ForumCategoryUpdateReqDto;
+import com.beyond.MKX.domain.forumCategory.service.command.ForumCategoryCommandService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/forum/categories")
+@RequiredArgsConstructor
+public class ForumCategoryCommandController {
+
+    private final ForumCategoryCommandService commandService;
+
+    /** 생성 */
+    @PostMapping
+    public ResponseEntity<?> create(@Valid @RequestBody ForumCategoryCreateReqDto req) {
+        ForumCategoryResDto res = commandService.create(req);
+        return ApiResponse.created(res, "포럼 카테고리 생성 성공");
+    }
+
+    /** 수정 */
+    @PatchMapping("/{id}")
+    public ResponseEntity<?> update(@PathVariable UUID id,
+                                    @Valid @RequestBody ForumCategoryUpdateReqDto req) {
+        ForumCategoryResDto res = commandService.update(id, req);
+        return ApiResponse.ok(res, "포럼 카테고리 수정 성공");
+    }
+
+    /** 소프트 삭제 */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> delete(@PathVariable UUID id) {
+        commandService.softDelete(id);
+        return ApiResponse.noContent(null, "포럼 카테고리 삭제(소프트) 성공");
+    }
+
+    /** 삭제 복구 */
+    @PostMapping("/{id}/restore")
+    public ResponseEntity<?> restore(@PathVariable UUID id) {
+        ForumCategoryResDto res = commandService.restore(id);
+        return ApiResponse.ok(res, "포럼 카테고리 복구 성공");
+    }
+}

--- a/community/src/main/java/com/beyond/MKX/domain/forumCategory/controller/ForumCategoryQueryController.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumCategory/controller/ForumCategoryQueryController.java
@@ -1,0 +1,57 @@
+package com.beyond.MKX.domain.forumCategory.controller;
+
+import com.beyond.MKX.common.apiResponse.ApiResponse;
+import com.beyond.MKX.domain.forumCategory.dto.ForumCategoryResDto;
+import com.beyond.MKX.domain.forumCategory.service.query.ForumCategoryQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/forum/categories")
+@RequiredArgsConstructor
+public class ForumCategoryQueryController {
+
+    private final ForumCategoryQueryService queryService;
+
+    /** 단건 조회 (삭제 포함) */
+    @GetMapping("/{id}")
+    public ResponseEntity<?> get(@PathVariable UUID id) {
+        ForumCategoryResDto res = queryService.get(id);
+        return ApiResponse.ok(res, "포럼 카테고리 조회 성공");
+    }
+
+    /** 전체 조회 (?deleted=all|only|exclude) - 기본 exclude(미삭제) */
+    @GetMapping
+    public ResponseEntity<?> list(@RequestParam(defaultValue = "exclude") String deleted,
+                                  Pageable pageable) {
+        Page<ForumCategoryResDto> page = queryService.list(deleted, pageable);
+        return ApiResponse.ok(page, "포럼 카테고리 목록 조회 성공");
+    }
+
+    /** 삭제된 것만 */
+    @GetMapping("/deleted")
+    public ResponseEntity<?> listDeleted(Pageable pageable) {
+        return ApiResponse.ok(queryService.list("only", pageable), "삭제된 카테고리 목록 조회 성공");
+    }
+
+    /** 미삭제(활성)만 */
+    @GetMapping("/active")
+    public ResponseEntity<?> listActive(Pageable pageable) {
+        return ApiResponse.ok(queryService.list("exclude", pageable), "활성 카테고리 목록 조회 성공");
+    }
+
+    /** 특정 사용자 기준 조회 (uuid 또는 userId 둘 중 하나 제공) */
+    @GetMapping("/by-user")
+    public ResponseEntity<?> listByUser(@RequestParam(required = false) UUID userUuid,
+                                        @RequestParam(required = false) String userId,
+                                        @RequestParam(defaultValue = "exclude") String deleted,
+                                        Pageable pageable) {
+        Page<ForumCategoryResDto> page = queryService.listByUser(userUuid, userId, deleted, pageable);
+        return ApiResponse.ok(page, "사용자 기준 카테고리 조회 성공");
+    }
+}

--- a/community/src/main/java/com/beyond/MKX/domain/forumCategory/dto/ForumCategoryCreateReqDto.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumCategory/dto/ForumCategoryCreateReqDto.java
@@ -1,0 +1,15 @@
+package com.beyond.MKX.domain.forumCategory.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ForumCategoryCreateReqDto(
+        @NotBlank @Size(max = 25) String name,
+        @NotBlank @Size(max = 255) String description,
+        UUID createdBy,          // 선택: 관리자/작성자 UUID
+        String createdByUserId   // 선택: 관리자 계정 ID 등
+) {}

--- a/community/src/main/java/com/beyond/MKX/domain/forumCategory/dto/ForumCategoryResDto.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumCategory/dto/ForumCategoryResDto.java
@@ -1,0 +1,18 @@
+package com.beyond.MKX.domain.forumCategory.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ForumCategoryResDto(
+        UUID id,
+        String name,
+        String description,
+        UUID createdBy,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        LocalDateTime deletedAt,
+        long version
+) {}

--- a/community/src/main/java/com/beyond/MKX/domain/forumCategory/dto/ForumCategoryUpdateReqDto.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumCategory/dto/ForumCategoryUpdateReqDto.java
@@ -1,0 +1,10 @@
+package com.beyond.MKX.domain.forumCategory.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.Size;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ForumCategoryUpdateReqDto(
+        @Size(max = 25) String name,
+        @Size(max = 255) String description
+) {}

--- a/community/src/main/java/com/beyond/MKX/domain/forumCategory/entity/ForumCategory.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumCategory/entity/ForumCategory.java
@@ -1,0 +1,55 @@
+package com.beyond.MKX.domain.forumCategory.entity;
+
+import com.beyond.MKX.common.domain.BaseIdAndTimeEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(
+        name = "forum_category",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_forum_category_name", columnNames = "name")
+        },
+        indexes = {
+                @Index(name = "idx_forum_category_created_at", columnList = "created_at"),
+                @Index(name = "idx_forum_category_deleted_at", columnList = "deleted_at")
+        }
+)
+
+@SQLDelete(sql = """
+UPDATE forum_category
+SET deleted_at = CURRENT_TIMESTAMP,
+    version = version + 1
+WHERE id = ? AND version = ?
+""")
+@SQLRestriction("deleted_at IS NULL")
+public class ForumCategory extends BaseIdAndTimeEntity {
+
+    @Size(max = 25) // 실무에선 DTO에서 검증 권장
+    @Column(name = "name", nullable = false, length = 25)
+    private String name;
+
+    @Size(max = 255)
+    @Column(name = "description", nullable = false, length = 255)
+    private String description;
+
+    @Column(name = "created_by", nullable = false, updatable = false)
+    @Comment("관리자 아이디")
+    private UUID createdBy;
+
+    /** 동시성 제어(낙관적 락) - 선택이지만 권장 */
+    @Version
+    @Column(name = "version", nullable = false)
+    private long version;
+}

--- a/community/src/main/java/com/beyond/MKX/domain/forumCategory/repository/ForumCategoryQueryRepository.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumCategory/repository/ForumCategoryQueryRepository.java
@@ -1,0 +1,72 @@
+package com.beyond.MKX.domain.forumCategory.repository;
+
+import com.beyond.MKX.domain.forumCategory.entity.ForumCategory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * 조회 전용 레포지토리 (삭제 포함/전용/미삭제, 작성자 기준 등)
+ * - @SQLRestriction("deleted_at IS NULL")이 엔티티에 걸려 있어도,
+ *   아래 네이티브 쿼리는 해당 제약의 영향을 받지 않습니다.
+ */
+public interface ForumCategoryQueryRepository extends JpaRepository<ForumCategory, UUID> {
+
+    /* 단건(삭제 포함) */
+    @Query(value = "SELECT * FROM forum_category WHERE id = :id", nativeQuery = true)
+    Optional<ForumCategory> findOneIncludingDeleted(@Param("id") UUID id);
+
+    /* 전체(삭제 포함) */
+    @Query(value = "SELECT * FROM forum_category ORDER BY created_at DESC",
+            countQuery = "SELECT COUNT(*) FROM forum_category",
+            nativeQuery = true)
+    Page<ForumCategory> findAllIncludingDeleted(Pageable pageable);
+
+    /* 삭제 전용 */
+    @Query(value = "SELECT * FROM forum_category WHERE deleted_at IS NOT NULL ORDER BY deleted_at DESC",
+            countQuery = "SELECT COUNT(*) FROM forum_category WHERE deleted_at IS NOT NULL",
+            nativeQuery = true)
+    Page<ForumCategory> findDeletedOnly(Pageable pageable);
+
+    /* 미삭제(활성) 전용 */
+    @Query(value = "SELECT * FROM forum_category WHERE deleted_at IS NULL ORDER BY created_at DESC",
+            countQuery = "SELECT COUNT(*) FROM forum_category WHERE deleted_at IS NULL",
+            nativeQuery = true)
+    Page<ForumCategory> findActiveOnly(Pageable pageable);
+
+    /* 특정 사용자(UUID) */
+    @Query(value = "SELECT * FROM forum_category WHERE created_by = :uid ORDER BY created_at DESC",
+            countQuery = "SELECT COUNT(*) FROM forum_category WHERE created_by = :uid",
+            nativeQuery = true)
+    Page<ForumCategory> findAllByCreator(@Param("uid") UUID userUuid, Pageable pageable);
+
+    @Query(value = "SELECT * FROM forum_category WHERE created_by = :uid AND deleted_at IS NULL ORDER BY created_at DESC",
+            countQuery = "SELECT COUNT(*) FROM forum_category WHERE created_by = :uid AND deleted_at IS NULL",
+            nativeQuery = true)
+    Page<ForumCategory> findActiveByCreator(@Param("uid") UUID userUuid, Pageable pageable);
+
+    @Query(value = "SELECT * FROM forum_category WHERE created_by = :uid AND deleted_at IS NOT NULL ORDER BY deleted_at DESC",
+            countQuery = "SELECT COUNT(*) FROM forum_category WHERE created_by = :uid AND deleted_at IS NOT NULL",
+            nativeQuery = true)
+    Page<ForumCategory> findDeletedByCreator(@Param("uid") UUID userUuid, Pageable pageable);
+
+    /* 특정 사용자(UserId 문자열) — created_by_user_id 컬럼이 있는 경우 */
+    @Query(value = "SELECT * FROM forum_category WHERE created_by_user_id = :userId ORDER BY created_at DESC",
+            countQuery = "SELECT COUNT(*) FROM forum_category WHERE created_by_user_id = :userId",
+            nativeQuery = true)
+    Page<ForumCategory> findAllByCreatorUserId(@Param("userId") String userId, Pageable pageable);
+
+    @Query(value = "SELECT * FROM forum_category WHERE created_by_user_id = :userId AND deleted_at IS NULL ORDER BY created_at DESC",
+            countQuery = "SELECT COUNT(*) FROM forum_category WHERE created_by_user_id = :userId AND deleted_at IS NULL",
+            nativeQuery = true)
+    Page<ForumCategory> findActiveByCreatorUserId(@Param("userId") String userId, Pageable pageable);
+
+    @Query(value = "SELECT * FROM forum_category WHERE created_by_user_id = :userId AND deleted_at IS NOT NULL ORDER BY deleted_at DESC",
+            countQuery = "SELECT COUNT(*) FROM forum_category WHERE created_by_user_id = :userId AND deleted_at IS NOT NULL",
+            nativeQuery = true)
+    Page<ForumCategory> findDeletedByCreatorUserId(@Param("userId") String userId, Pageable pageable);
+}

--- a/community/src/main/java/com/beyond/MKX/domain/forumCategory/repository/ForumCategoryRepository.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumCategory/repository/ForumCategoryRepository.java
@@ -1,0 +1,23 @@
+package com.beyond.MKX.domain.forumCategory.repository;
+
+import com.beyond.MKX.domain.forumCategory.entity.ForumCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ForumCategoryRepository extends JpaRepository<ForumCategory, UUID> {
+
+    /** 단건(삭제 포함) — Command 경로에서 복구/재삭제 등을 위해 필요 */
+    @Query(value = "SELECT * FROM forum_category WHERE id = :id", nativeQuery = true)
+    Optional<ForumCategory> findOneIncludingDeleted(@Param("id") UUID id);
+
+    /** 활성(미삭제)만 — 수정 시 보수적으로 사용하고 싶다면 활용 */
+    @Query(value = "SELECT * FROM forum_category WHERE id = :id AND deleted_at IS NULL", nativeQuery = true)
+    Optional<ForumCategory> findActiveById(@Param("id") UUID id);
+
+    /** 이름 중복 검사 (수정/생성시 사용 가능) */
+    boolean existsByName(String name);
+}

--- a/community/src/main/java/com/beyond/MKX/domain/forumCategory/service/command/ForumCategoryCommandService.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumCategory/service/command/ForumCategoryCommandService.java
@@ -1,0 +1,15 @@
+package com.beyond.MKX.domain.forumCategory.service.command;
+
+import com.beyond.MKX.domain.forumCategory.dto.ForumCategoryCreateReqDto;
+import com.beyond.MKX.domain.forumCategory.dto.ForumCategoryResDto;
+import com.beyond.MKX.domain.forumCategory.dto.ForumCategoryUpdateReqDto;
+
+import java.util.UUID;
+
+public interface ForumCategoryCommandService {
+    ForumCategoryResDto create(ForumCategoryCreateReqDto req);
+    ForumCategoryResDto update(UUID id, ForumCategoryUpdateReqDto req);
+    void softDelete(UUID id);
+    ForumCategoryResDto restore(UUID id);
+}
+

--- a/community/src/main/java/com/beyond/MKX/domain/forumCategory/service/command/ForumCategoryCommandServiceImpl.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumCategory/service/command/ForumCategoryCommandServiceImpl.java
@@ -1,0 +1,99 @@
+package com.beyond.MKX.domain.forumCategory.service.command;
+
+import com.beyond.MKX.domain.forumCategory.dto.ForumCategoryCreateReqDto;
+import com.beyond.MKX.domain.forumCategory.dto.ForumCategoryResDto;
+import com.beyond.MKX.domain.forumCategory.dto.ForumCategoryUpdateReqDto;
+import com.beyond.MKX.domain.forumCategory.entity.ForumCategory;
+import com.beyond.MKX.domain.forumCategory.repository.ForumCategoryRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ForumCategoryCommandServiceImpl implements ForumCategoryCommandService {
+
+    private final ForumCategoryRepository repo;
+
+    @Override
+    public ForumCategoryResDto create(ForumCategoryCreateReqDto req) {
+        if (repo.existsByName(req.name())) {
+            throw new IllegalArgumentException("이미 존재하는 카테고리명입니다: " + req.name());
+        }
+
+        ForumCategory e = ForumCategory.builder()
+                .name(req.name())
+                .description(req.description())
+                .createdBy(req.createdBy())
+                .build();
+
+        ForumCategory saved = repo.save(e);
+        return map(saved);
+    }
+
+    @Override
+    public ForumCategoryResDto update(UUID id, ForumCategoryUpdateReqDto req) {
+        // 삭제 포함으로 조회(복구/이력 유지 가정). 활성만 허용하려면 findActiveById 사용
+        ForumCategory e = repo.findOneIncludingDeleted(id)
+                .orElseThrow(() -> new EntityNotFoundException("ForumCategory not found: " + id));
+
+        if (req.name() != null && !req.name().equals(e.getName())) {
+            // (선택) 이름 변경 시 중복 체크
+            if (repo.existsByName(req.name())) {
+                throw new IllegalArgumentException("이미 존재하는 카테고리명입니다: " + req.name());
+            }
+            e.setName(req.name());
+        }
+        if (req.description() != null) {
+            e.setDescription(req.description());
+        }
+
+        try {
+            return map(repo.save(e)); // @Version으로 낙관적 락 검증
+        } catch (OptimisticLockingFailureException ex) {
+            throw new IllegalStateException("동시 수정 충돌이 발생했습니다. 다시 시도하세요.", ex);
+        }
+    }
+
+    @Override
+    public void softDelete(UUID id) {
+        ForumCategory e = repo.findOneIncludingDeleted(id)
+                .orElseThrow(() -> new EntityNotFoundException("ForumCategory not found: " + id));
+
+        if (e.getDeletedAt() == null) {
+            e.markDeleted();         // UPDATE 경로 → @Version 검증이 적용됨
+            repo.save(e);
+        }
+        // 이미 삭제된 경우는 멱등 처리
+    }
+
+    @Override
+    public ForumCategoryResDto restore(UUID id) {
+        ForumCategory e = repo.findOneIncludingDeleted(id)
+                .orElseThrow(() -> new EntityNotFoundException("ForumCategory not found: " + id));
+
+        if (e.getDeletedAt() != null) {
+            e.restore();             // UPDATE 경로 → @Version 검증
+            e = repo.save(e);
+        }
+        return map(e);
+    }
+
+    private static ForumCategoryResDto map(ForumCategory e) {
+        return new ForumCategoryResDto(
+                e.getId(),
+                e.getName(),
+                e.getDescription(),
+                e.getCreatedBy(),
+                e.getCreatedAt(),
+                e.getUpdatedAt(),
+                e.getDeletedAt(),
+                e.getVersion()
+        );
+    }
+}

--- a/community/src/main/java/com/beyond/MKX/domain/forumCategory/service/query/ForumCategoryQueryService.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumCategory/service/query/ForumCategoryQueryService.java
@@ -1,0 +1,19 @@
+package com.beyond.MKX.domain.forumCategory.service.query;
+
+import com.beyond.MKX.domain.forumCategory.dto.ForumCategoryResDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
+
+public interface ForumCategoryQueryService {
+
+    /** 단건(삭제 포함) */
+    ForumCategoryResDto get(UUID id);
+
+    /** 목록 (?deleted=all|only|exclude) */
+    Page<ForumCategoryResDto> list(String deleted, Pageable pageable);
+
+    /** 특정 사용자 기준 (uuid 또는 userId) */
+    Page<ForumCategoryResDto> listByUser(UUID userUuid, String userId, String deleted, Pageable pageable);
+}

--- a/community/src/main/java/com/beyond/MKX/domain/forumCategory/service/query/ForumCategoryQueryServiceImpl.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumCategory/service/query/ForumCategoryQueryServiceImpl.java
@@ -1,0 +1,69 @@
+package com.beyond.MKX.domain.forumCategory.service.query;
+
+import com.beyond.MKX.domain.forumCategory.dto.ForumCategoryResDto;
+import com.beyond.MKX.domain.forumCategory.entity.ForumCategory;
+import com.beyond.MKX.domain.forumCategory.repository.ForumCategoryQueryRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ForumCategoryQueryServiceImpl implements ForumCategoryQueryService {
+
+    private final ForumCategoryQueryRepository repo;
+
+    @Override
+    public ForumCategoryResDto get(UUID id) {
+        ForumCategory e = repo.findOneIncludingDeleted(id)
+                .orElseThrow(() -> new EntityNotFoundException("ForumCategory not found: " + id));
+        return map(e);
+    }
+
+    @Override
+    public Page<ForumCategoryResDto> list(String deleted, Pageable pageable) {
+        return switch (deleted) {
+            case "all"  -> repo.findAllIncludingDeleted(pageable).map(this::map);
+            case "only" -> repo.findDeletedOnly(pageable).map(this::map);
+            default     -> repo.findActiveOnly(pageable).map(this::map); // exclude
+        };
+    }
+
+    @Override
+    public Page<ForumCategoryResDto> listByUser(UUID userUuid, String userId, String deleted, Pageable pageable) {
+        if (userUuid != null) {
+            return switch (deleted) {
+                case "all"  -> repo.findAllByCreator(userUuid, pageable).map(this::map);
+                case "only" -> repo.findDeletedByCreator(userUuid, pageable).map(this::map);
+                default     -> repo.findActiveByCreator(userUuid, pageable).map(this::map);
+            };
+        }
+        if (userId != null && !userId.isBlank()) {
+            return switch (deleted) {
+                case "all"  -> repo.findAllByCreatorUserId(userId, pageable).map(this::map);
+                case "only" -> repo.findDeletedByCreatorUserId(userId, pageable).map(this::map);
+                default     -> repo.findActiveByCreatorUserId(userId, pageable).map(this::map);
+            };
+        }
+        return Page.empty(pageable);
+    }
+
+    private ForumCategoryResDto map(ForumCategory e) {
+        return new ForumCategoryResDto(
+                e.getId(),
+                e.getName(),
+                e.getDescription(),
+                e.getCreatedBy(),
+                e.getCreatedAt(),
+                e.getUpdatedAt(),
+                e.getDeletedAt(),
+                e.getVersion()
+        );
+    }
+}


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
포럼 카테고리 도메인 CRUD(생성/수정/소프트삭제/복구) + 조회(단건/목록/필터/사용자별) 전반 구현 및 API 공개

<br/>

## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- Controller
  - ForumCategoryCommandController: POST /api/forum/categories, PATCH /{id}, DELETE /{id}, POST /{id}/restore
  - ForumCategoryQueryController: GET /{id}, GET /, GET /deleted, GET /active, GET /by-user
  - 공통 응답 ApiResponse.(created|ok|noContent) 적용, @Valid 검증 연동
- DTO
  - ForumCategoryCreateReqDto: @NotBlank, 길이 제한(name ≤25, description ≤255), 선택 필드 createdBy, createdByUserId
  - ForumCategoryUpdateReqDto: 부분 수정(PATCH)용 선택 필드, 길이 제한
  - ForumCategoryResDto: 불변 record, NON_NULL 직렬화
- Entity
  - ForumCategory: name 유니크, 인덱스(created_at, deleted_at), @SQLDelete/@SQLRestriction로 소프트 삭제
  - @Version 낙관적 락(동시성 제어), createdBy(UUID) 보존
- Repository
  - ForumCategoryRepository: 단건(삭제 포함), 활성 단건, existsByName 중복 검사
  - ForumCategoryQueryRepository: native 쿼리 기반 전체/활성/삭제 전용, 작성자(UUID/userId) 필터 + 페이지네이션
- Service
  - Command: 생성/수정/소프트삭제/복구, 이름 중복/상태 검증, 낙관적 락 예외 처리
  - Query: deleted=all|only|exclude 스위치 로직, UUID/userId 기준 조회, 미제공 시 Page.empty(pageable)
- 유효성/예외
  - IllegalArgumentException(이름 중복), EntityNotFoundException(없음), OptimisticLockingFailureException 처리

<img width="1405" height="627" alt="image" src="https://github.com/user-attachments/assets/7b01e0e0-f28a-408b-9d45-aaeb6693a59c" />
- 기존 ERD에는 반영되어 있지 않은 포럼 요구사항이 있어 투표 관련 테이블인 포럼_투표, 포럼_투표_기록, 포럼_투표_선택지 테이블과 카테고리 관련 테이블인 포럼_게시글_카테고리, 포럼_카테고리 테이블이 추가되었습니다.
<br/>

## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #46 

<br/>

## 🧪 테스트 결과
<!-- 코드 검증 시 진행한 테스트 결과에 대한 캡쳐 이미지나 영상 혹은 기타 자료를 첨부해주세요. -->
<!-- 어떤 방식으로 테스트를 진행 하였으며, 왜 그 방식을 채택 했는지에 대한 설명도 작성해주세요. -->
<!-- 성능 테스트 방식이 잘못 되었거나 누락 되어있다면 PR은 거절됩니다. -->
<img width="1176" height="713" alt="image" src="https://github.com/user-attachments/assets/3dc5eb81-09d6-40f4-8433-3a29e9db78bd" />
<img width="1171" height="655" alt="image" src="https://github.com/user-attachments/assets/71422237-7ac2-490a-9a1d-016c43fb19ee" />
<img width="1172" height="567" alt="image" src="https://github.com/user-attachments/assets/319357f1-7924-4f37-a12e-d7d6d2a53b40" />
<img width="1161" height="581" alt="image" src="https://github.com/user-attachments/assets/9ea286b8-dbe3-4739-a5ee-ba8a1753724d" />
<img width="1167" height="678" alt="image" src="https://github.com/user-attachments/assets/d74c6e04-e931-422a-9877-bb0bb2501d62" />
<img width="1170" height="417" alt="image" src="https://github.com/user-attachments/assets/aa446c3d-1451-4dbc-94da-a6424359654c" />
<img width="1170" height="642" alt="image" src="https://github.com/user-attachments/assets/a878ef09-71bd-4256-aef9-c3754b5d66f9" />
<img width="1171" height="463" alt="image" src="https://github.com/user-attachments/assets/8213114c-0385-497b-9696-420ea24cce2f" />
<img width="1162" height="651" alt="image" src="https://github.com/user-attachments/assets/68bf124a-acf6-485d-98ff-d5d23ac416e7" />
<img width="1172" height="960" alt="image" src="https://github.com/user-attachments/assets/a31abe74-6ec9-4cdb-9ebf-2f5a05a27073" />
<img width="1170" height="988" alt="image" src="https://github.com/user-attachments/assets/d7263d2d-4fad-4376-9b59-e33dfe5ca8cd" />
(삭제 전)
<img width="1170" height="988" alt="image" src="https://github.com/user-attachments/assets/052a4329-be11-4cd2-98e9-b86fdb2541a7" />
(삭제 후)
<img width="1153" height="986" alt="image" src="https://github.com/user-attachments/assets/bd92a311-127b-4822-b79c-7c049394b14e" />
<img width="1172" height="996" alt="image" src="https://github.com/user-attachments/assets/d5e62006-7061-45bf-ad4d-a5812bd4556c" />

<br/>

## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
- 이후 forumPost와 연계되어 사용 될 예정입니다.
- 기존 ERD가 포럼쪽 요구사항에 미달하는 부분이 있어 대폭 수정하였습니다.
- 투표 기능과 관련된 테이블인 포럼_투표, 포럼_투표_기록, 포럼_투표_선택지 테이블이 추가되었습니다.
- 카테고리 기능과 관련된 테이블인 포럼_카테고리와 포럼_게시글_카테고리 테이블이 추가되었습니다.
- 두개 모두 연결 테이블을 만들어 유저가 투표를 만들 때 2개 이상의 선택지를 설정 할 수 있으며, 게시글을 쓸 때 1개 이상의 카테고리를 설정할 수 있도록 하여 추후 확장성 및 자유도를 높혔습니다. 
<img width="1405" height="627" alt="image" src="https://github.com/user-attachments/assets/c013f99c-6752-4966-93d5-d76808b7199d" />

<br/>

## 👥 리뷰어 지정
<!-- 반드시 2명 이상 리뷰어를 지정해주세요 -->
<!-- 모든 리뷰어가 PR 리뷰를 마친 뒤 병합을 진행합니다. -->
<!-- 예: @username1 @username2 -->
@jinnn12 @ggj0228 

<br/>

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: Feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.
- [x] 코드에 대한 테스트를 진행 하였으며, 결과에 대한 자료를 첨부하였습니다.
- [x] 최소 2명의 리뷰어를 지정했습니다.