### PR TITLE
[Feat] 주문 상태 카프카 메시지 구조 수정 (총 체결 금액 추가) (#52)

### DIFF
--- a/matching-engine/src/main/java/com/beyond/MKX/domain/order/service/MatchingEngineService.java
+++ b/matching-engine/src/main/java/com/beyond/MKX/domain/order/service/MatchingEngineService.java
@@ -10,19 +10,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 
 /**
  * 매칭 엔진 서비스.
  *
- * 역할
- * - 주문 이벤트(OrderEvent)를 유형별로 처리(LIMIT / MARKET / CANCEL)
- * - Redis 오더북 리포지토리와 Lua 스크립트를 통해 매칭 수행
- * - 체결(Execution) 및 상태(OrderStatus) 카프카 이벤트 발행
- *
- * 수치 원칙
- * - 가격: KRW 정수 long (부동소수점 오차 방지)
- * - 수량·잔량·누적: BigDecimal
+ * 전제
+ * - 원화 정수 가격(long), 소수점 없는 정수 수량만 허용(주문·체결 모두)
+ * - 총 체결 금액(totalAmount)은 원화 정수의 합계(소수 불가)
  */
 @Service
 @RequiredArgsConstructor
@@ -33,13 +27,22 @@ public class MatchingEngineService {
     private final KafkaOrderProducer kafkaOrderProducer;
 
     /** 한 번의 Lua 실행에서 소비할 최대 매칭 수(과도한 처리 방지) */
-    // TODO: 팀원과 상의 후 MAX_MATCHES_PER_CALL 값 확정 짓기
     private static final int MAX_MATCHES_PER_CALL = 200;
+
+    /** BigDecimal 수량이 정수인지 검증하고 long으로 변환(정수가 아니면 예외) */
+    private static long toUnitsExact(BigDecimal q, String fieldName) {
+        if (q == null) {
+            throw new IllegalArgumentException(fieldName + " is required");
+        }
+        // 소수점 수량 방지: scale==0 인지 확인
+        if (q.stripTrailingZeros().scale() > 0) {
+            throw new IllegalArgumentException(fieldName + " must be an integer quantity (no decimals)");
+        }
+        return q.longValueExact();
+    }
 
     /**
      * 주문 이벤트 엔트리 포인트.
-     * - 이벤트 null/유형 누락 시 경고 로그 후 무시
-     * - 유형별 핸들러 위임
      */
     public void process(OrderEvent event) {
         if (event == null || event.getOrderType() == null) {
@@ -49,13 +52,12 @@ public class MatchingEngineService {
 
         try {
             switch (event.getOrderType()) {
-                case "LIMIT" -> handleLimit(event);   // 지정가: 매칭 시도 후 잔량은 오더북 적재
-                case "MARKET" -> handleMarket(event); // 시장가: 매칭만(잔량 미적재), 가격가드 사용
+                case "LIMIT" -> handleLimit(event);   // 지정가 (잔량 적재)
+                case "MARKET" -> handleMarket(event); // 시장가 (잔량 미적재)
                 case "CANCEL" -> handleCancel(event); // 취소
                 default -> log.warn("Unknown order type: {}", event.getOrderType());
             }
         } catch (Exception ex) {
-            // 예외는 에러 토픽으로 전달하여 상위(브로커리지/게이트웨이)에서 알림 가능
             log.error("Processing failed for event: {}", event, ex);
             kafkaOrderProducer.sendError(
                     event.getOrderId() != null ? event.getOrderId() : "UNKNOWN",
@@ -65,10 +67,7 @@ public class MatchingEngineService {
     }
 
     /**
-     * 지정가 주문 처리:
-     * 1) 가격 가드 = 지정가로 매칭 시도
-     * 2) 잔량이 있으면 동일 orderId/가격으로 즉시 오더북 적재(Repo/Lua가 처리)
-     * 3) 체결 건마다 executions 발행, 요약 상태를 order-status로 발행
+     * 지정가 주문 처리
      */
     private void handleLimit(OrderEvent e) {
         // --- 입력 검증 ---
@@ -78,73 +77,83 @@ public class MatchingEngineService {
         requirePositive(e.getQuantity(), "quantity");
         requirePositive(e.getPrice(),    "price");
 
-        // 입력값을 엔진 내부 표현으로 변환
-        final BigDecimal reqQty     = e.getQuantity();
-        final long       guardPxInt = redisRepo.asIntPrice(e.getPrice()); // 지정가 → KRW 정수
-        final long       limitPxInt = guardPxInt;
+        // 정수 수량 전제 확인(요청 수량도 정수만 허용)
+        final long reqUnits = toUnitsExact(e.getQuantity(), "quantity");
+
+        final BigDecimal reqQtyBD = e.getQuantity(); // 외부 인터페이스 호환용
+        final long guardPxInt = redisRepo.asIntPrice(e.getPrice()); // 지정가 → KRW 정수
+        final long limitPxInt = guardPxInt;
 
         // 매칭 + (잔량 시) 동일 orderId/가격으로 적재
         MatchResult res = redisRepo.matchOrAddLimit(
                 e.getTicker(),
                 e.getSide(),
-                reqQty,       // 레포는 아직 double 인터페이스 → 향후 BigDecimal로 변경 권장
+                reqQtyBD,                 // 레포 인터페이스(BigDecimal) 유지
                 MAX_MATCHES_PER_CALL,
                 guardPxInt,
                 e.getOrderId(),
                 guardPxInt
         );
 
-        // --- 체결 집계: notional(정수 KRW * 수량) / 누적 수량(BigDecimal) ---
-        BigDecimal filledQty = BigDecimal.ZERO;
-        BigDecimal notional  = BigDecimal.ZERO;
-        Long       lastPxInt = null;
+        // --- 체결 집계(정수만) ---
+        BigDecimal filledQtyBD = BigDecimal.ZERO; // 외부용
+        long filledUnits = 0L;                    // 내부 정수 집계
+        long notional    = 0L;                    // 총 체결 금액(원화 정수)
+        Long lastPxInt   = null;
 
         for (TradeFill f : res.fills()) {
-            // TradeFill은 (quantity=BigDecimal, price=long) 이라고 가정
-            BigDecimal q  = f.quantity(); // BigDecimal
-            long       px = f.price();    // KRW 정수
+            // 정수 수량만 허용
+            long units = toUnitsExact(f.quantity(), "fill.quantity");
+            long px    = f.price();
 
-            filledQty = filledQty.add(q);
-            notional  = notional.add(BigDecimal.valueOf(px).multiply(q));
-            lastPxInt = px;
+            // notional += px * units (오버플로우 방지)
+            long lineAmount = Math.multiplyExact(px, units);
+            notional        = Math.addExact(notional, lineAmount);
+            filledUnits     = Math.addExact(filledUnits, units);
+            lastPxInt       = px;
 
-            // 개별 체결 이벤트 발행(상대 주문 ID 포함) — ExecutionEvent는 여전히 double 기반이면 변환
+            // 외부 이벤트용 BigDecimal 수량은 그대로 전달(정수이지만 타입 유지)
+            filledQtyBD = filledQtyBD.add(f.quantity());
+
             kafkaOrderProducer.sendExecution(
                     e.getOrderId(),
                     e.getTicker(),
                     e.getSide(),
                     f.counterOrderId(),
-                    q,              // 외부 인터페이스 호환
-                    px                   // 외부 인터페이스 호환
+                    f.quantity(),
+                    px
             );
         }
 
-        Long vwapInt = filledQty.signum() > 0
-                ? notional.divide(filledQty, 0, RoundingMode.HALF_UP).longValueExact()
+        // 평균가(VWAP) 정수 반올림: notional / filledUnits (HALF_UP)
+        Long vwapInt = (filledUnits > 0)
+                ? ((notional + (filledUnits / 2)) / filledUnits)
                 : null;
 
-        // --- 상태 이벤트(완전/부분/무체결) ---
-        BigDecimal remainingBD = res.remaining(); // 레포 반환이 double → BD로 변환
+        BigDecimal remainingBD = res.remaining();
+        // remaining(잔량)도 정수만 허용
+        long remainingUnits = toUnitsExact(remainingBD, "remaining");
 
-        if (remainingBD.compareTo(BigDecimal.ZERO) <= 0) {
+        if (remainingUnits <= 0L) {
             // 완전 체결
             kafkaOrderProducer.sendMarketFilled(
                     e.getOrderId(), e.getTicker(), e.getSide(),
                     vwapInt != null ? vwapInt : 0L,
                     lastPxInt != null ? lastPxInt : 0L,
                     limitPxInt,
-                    filledQty
+                    filledQtyBD,
+                    notional
             );
-            log.info("LIMIT filled: {} {} {} filledQty={}", e.getOrderId(), e.getTicker(), e.getSide(), reqQty);
+            log.info("LIMIT filled: {} {} {} filledUnits={}", e.getOrderId(), e.getTicker(), e.getSide(), reqUnits);
         } else if (res.fills().isEmpty()) {
-            // 전혀 체결 아님 → 잔량 적재 보강(동일 키가 없을 때만)
+            // 무체결 → 잔량 적재 보강
             boolean added = redisRepo.ensureLimitOrderPresent(
-                    e.getTicker(), e.getOrderId(), e.getSide(), e.getPrice(), reqQty);
-            kafkaOrderProducer.sendNewAccepted(e.getOrderId(), e.getTicker(), e.getSide(), e.getPrice(), reqQty);
+                    e.getTicker(), e.getOrderId(), e.getSide(), e.getPrice(), reqQtyBD);
+            kafkaOrderProducer.sendNewAccepted(e.getOrderId(), e.getTicker(), e.getSide(), e.getPrice(), reqQtyBD);
             log.info("LIMIT accepted(no fills): {} {} {} qty={} price={} (fallbackAdded={})",
-                    e.getOrderId(), e.getTicker(), e.getSide(), reqQty, e.getPrice(), added);
+                    e.getOrderId(), e.getTicker(), e.getSide(), reqQtyBD, e.getPrice(), added);
         } else {
-            // 부분 체결 + 잔량 적재 보강
+            // 부분 체결
             boolean added = redisRepo.ensureLimitOrderPresent(
                     e.getTicker(), e.getOrderId(), e.getSide(), e.getPrice(), remainingBD);
 
@@ -154,19 +163,17 @@ public class MatchingEngineService {
                     vwapInt != null ? vwapInt : 0L,
                     lastPxInt != null ? lastPxInt : 0L,
                     limitPxInt,
-                    filledQty
+                    filledQtyBD,
+                    notional
             );
 
-            log.info("LIMIT partial: {} {} {} remaining={} (fallbackAdded={})",
-                    e.getOrderId(), e.getTicker(), e.getSide(), remainingBD, added);
+            log.info("LIMIT partial: {} {} {} remainingUnits={} (fallbackAdded={})",
+                    e.getOrderId(), e.getTicker(), e.getSide(), remainingUnits, added);
         }
     }
 
     /**
-     * 시장가 주문 처리:
-     * 1) 가격 가드 = 이벤트 price로 매칭만 수행
-     * 2) 잔량은 오더북에 적재하지 않음
-     * 3) 체결 건마다 executions 발행, 요약 상태를 order-status로 발행
+     * 시장가 주문 처리
      */
     private void handleMarket(OrderEvent mkt) {
         requireNonEmpty(mkt.getTicker(), "ticker");
@@ -175,82 +182,87 @@ public class MatchingEngineService {
         requirePositive(mkt.getQuantity(), "quantity");
         requirePositive(mkt.getPrice(),    "guard price");
 
-        final BigDecimal reqQty     = mkt.getQuantity();
-        final long       guardPxInt = redisRepo.asIntPrice(mkt.getPrice());
-        final long       limitPxInt = guardPxInt; // MARKET의 limitPrice 필드는 '가드 가격' 의미로 재사용
+        // 시장가도 정수 수량만 허용
+        final long reqUnits = toUnitsExact(mkt.getQuantity(), "quantity");
 
-        // 시장가: 잔량 미적재 → orderIdToAdd="", priceIntForAdd=0
+        final BigDecimal reqQtyBD = mkt.getQuantity();
+        final long guardPxInt = redisRepo.asIntPrice(mkt.getPrice());
+        final long limitPxInt = guardPxInt;
+
+        // 시장가: 잔량 미적재
         MatchResult res = redisRepo.matchOrAddLimit(
                 mkt.getTicker(),
                 mkt.getSide(),
-                reqQty,   // 레포 인터페이스 호환
+                reqQtyBD,
                 MAX_MATCHES_PER_CALL,
                 guardPxInt,
                 "",
                 0L
         );
 
-        // --- 체결 집계 ---
-        BigDecimal filledQty = BigDecimal.ZERO;
-        BigDecimal notional  = BigDecimal.ZERO;
-        Long       lastPxInt = null;
+        BigDecimal filledQtyBD = BigDecimal.ZERO;
+        long filledUnits = 0L;
+        long notional    = 0L;
+        Long lastPxInt   = null;
 
         for (TradeFill f : res.fills()) {
-            BigDecimal q  = f.quantity();
-            long       px = f.price();
+            long units = toUnitsExact(f.quantity(), "fill.quantity");
+            long px    = f.price();
 
-            filledQty = filledQty.add(q);
-            notional  = notional.add(BigDecimal.valueOf(px).multiply(q));
-            lastPxInt = px;
+            long lineAmount = Math.multiplyExact(px, units);
+            notional        = Math.addExact(notional, lineAmount);
+            filledUnits     = Math.addExact(filledUnits, units);
+            lastPxInt       = px;
+
+            filledQtyBD = filledQtyBD.add(f.quantity());
 
             kafkaOrderProducer.sendExecution(
                     mkt.getOrderId(),
                     mkt.getTicker(),
                     mkt.getSide(),
                     f.counterOrderId(),
-                    q,
+                    f.quantity(),
                     px
             );
         }
 
-        Long vwapInt = filledQty.signum() > 0
-                ? notional.divide(filledQty, 0, RoundingMode.HALF_UP).longValueExact()
+        Long vwapInt = (filledUnits > 0)
+                ? ((notional + (filledUnits / 2)) / filledUnits)
                 : null;
 
         BigDecimal remainingBD = res.remaining();
+        long remainingUnits = toUnitsExact(remainingBD, "remaining");
 
-        if (remainingBD.compareTo(BigDecimal.ZERO) <= 0) {
+        if (remainingUnits <= 0L) {
             // 완전 체결
             kafkaOrderProducer.sendMarketFilled(
                     mkt.getOrderId(), mkt.getTicker(), mkt.getSide(),
                     vwapInt != null ? vwapInt : 0L,
                     lastPxInt != null ? lastPxInt : 0L,
                     limitPxInt,
-                    filledQty
+                    filledQtyBD,
+                    notional
             );
-            log.info("MARKET filled: {} ticker={} side={} filledQty={}", mkt.getOrderId(), mkt.getTicker(), mkt.getSide(), reqQty);
+            log.info("MARKET filled: {} ticker={} side={} filledUnits={}", mkt.getOrderId(), mkt.getTicker(), mkt.getSide(), reqUnits);
         } else if (res.fills().isEmpty()) {
-            // 가드 범위 내 반대 호가 없음 → 대기(체결 X)
             kafkaOrderProducer.sendWaiting(mkt.getOrderId(), mkt.getTicker(), mkt.getSide());
             log.info("MARKET waiting: {} (no opposite within guard)", mkt.getOrderId());
         } else {
-            // 부분 체결
             kafkaOrderProducer.sendMarketPartial(
                     mkt.getOrderId(), mkt.getTicker(), mkt.getSide(),
                     remainingBD,
                     vwapInt != null ? vwapInt : 0L,
                     lastPxInt != null ? lastPxInt : 0L,
                     limitPxInt,
-                    filledQty
+                    filledQtyBD,
+                    notional
             );
-            log.info("MARKET partial: {} ticker={} side={} remaining={}", mkt.getOrderId(), mkt.getTicker(), mkt.getSide(), remainingBD);
+            log.info("MARKET partial: {} ticker={} side={} remainingUnits={}", mkt.getOrderId(), mkt.getTicker(), mkt.getSide(), remainingUnits);
         }
     }
 
     /**
-     * 취소 주문 처리:
-     * - 오더북 ZSET/주문 상세/인덱스를 제거
-     * - CANCEL_OK 상태 이벤트 발행
+     * 취소 주문 처리
      */
     private void handleCancel(OrderEvent e) {
         requireNonEmpty(e.getTicker(), "ticker");
@@ -275,7 +287,6 @@ public class MatchingEngineService {
             throw new IllegalArgumentException(field + " must be > 0");
         }
     }
-
     private static void requirePositive(long v, String field) {
         if (v <= 0L) {
             throw new IllegalArgumentException(field + " must be > 0");

--- a/matching-engine/src/main/java/com/beyond/MKX/infrastructure/kafka/AllTopicsLoggingConsumer.java
+++ b/matching-engine/src/main/java/com/beyond/MKX/infrastructure/kafka/AllTopicsLoggingConsumer.java
@@ -60,10 +60,10 @@ public class AllTopicsLoggingConsumer {
             @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
             @Header(KafkaHeaders.OFFSET) long offset
     ) {
-        log.info("[KAFKA/ORDER-STATUS] topic={} p={} off={} orderId={} status={} ticker={} side={} remaining={} price={} ts={}",
+        log.info("[KAFKA/ORDER-STATUS] topic={} p={} off={} orderId={} status={} ticker={} side={} remaining={} price={} notional={} ts={}",
                 topic, partition, offset,
                 payload.getOrderId(), payload.getStatus(), payload.getTicker(), payload.getSide(),
-                payload.getRemaining(), payload.getPrice(), payload.getTimestamp());
+                payload.getRemaining(), payload.getPrice(), payload.getNotional(), payload.getTimestamp());
     }
 
     /**

--- a/matching-engine/src/main/java/com/beyond/MKX/infrastructure/kafka/KafkaOrderProducer.java
+++ b/matching-engine/src/main/java/com/beyond/MKX/infrastructure/kafka/KafkaOrderProducer.java
@@ -105,7 +105,8 @@ public class KafkaOrderProducer {
      */
     public void sendMarketPartial(String orderId, String ticker, String side,
                                   BigDecimal remaining,
-                                  long vwap, long lastPrice, long limitPrice, BigDecimal filledQty) {
+                                  long vwap, long lastPrice, long limitPrice, BigDecimal filledQty,
+                                  long notional) {
         OrderStatusEvent evt = OrderStatusEvent.builder()
                 .orderId(orderId)
                 .ticker(ticker)
@@ -116,6 +117,7 @@ public class KafkaOrderProducer {
                 .lastFillPrice(lastPrice)
                 .limitPrice(limitPrice)
                 .filledQuantity(filledQty)
+                .notional(notional)
                 .timestamp(Instant.now().toEpochMilli())
                 .build();
         sendOrderStatus(ticker != null ? ticker : orderId, evt);
@@ -126,7 +128,8 @@ public class KafkaOrderProducer {
      * - 표시가격(price)은 '지정가(limitPrice)'로 고정한다.
      */
     public void sendMarketFilled(String orderId, String ticker, String side,
-                                 long vwap, long lastPrice, long limitPrice, BigDecimal filledQty) {
+                                 long vwap, long lastPrice, long limitPrice, BigDecimal filledQty,
+                                 long notional) {
         OrderStatusEvent evt = OrderStatusEvent.builder()
                 .orderId(orderId)
                 .ticker(ticker)
@@ -136,6 +139,7 @@ public class KafkaOrderProducer {
                 .lastFillPrice(lastPrice)
                 .limitPrice(limitPrice)
                 .filledQuantity(filledQty)
+                .notional(notional)
                 .timestamp(Instant.now().toEpochMilli())
                 .build();
         sendOrderStatus(ticker != null ? ticker : orderId, evt);

--- a/matching-engine/src/main/java/com/beyond/MKX/infrastructure/kafka/event/OrderStatusEvent.java
+++ b/matching-engine/src/main/java/com/beyond/MKX/infrastructure/kafka/event/OrderStatusEvent.java
@@ -22,6 +22,7 @@ import java.math.BigDecimal;
  * - lastFillPrice   : 마지막 체결가
  * - limitPrice      : 지정가(또는 시장가 가드 가격)
  * - filledQuantity  : 누적 체결 수량
+ * - notional        : 총 체결 금액(원화 정수, ∑(체결가*체결수량))
  */
 @Builder
 @Getter @Setter
@@ -40,4 +41,5 @@ public class OrderStatusEvent {
     private long lastFillPrice;
     private long limitPrice;
     private BigDecimal filledQuantity;
+    private long notional;
 }


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
매칭 엔진 정수 수량 전제 반영 및 총 체결가(notional) 집계/전달, 그리고 ORDER-STATUS 로그에 notional 출력 추가.

<br/>

## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- MatchingEngineService
  - 수량 정수 전제 강화: toUnitsExact(BigDecimal)로 정수 수량만 허용, 소수 입력 시 예외 처리.
  - 체결 집계 정수화: filledUnits(long), notional(long=∑price×units)로 오버플로우 안전 집계(Math.multiplyExact, Math.addExact).
  - 상태 이벤트 전송 시 notional 전달: sendMarketPartial, sendMarketFilled 호출부 마지막 인자로 총 체결가 전달.
- KafkaOrderProducer
  - OrderStatusEvent에 총 체결 금액 필드 포함(스키마 반영 완료).
- AllTopicsLoggingConsumer
  - ORDER-STATUS 로그 포맷에 notional(총 체결가) 추가 출력.
  - 로그 라인: status, ticker, side, remaining, price, notional, ts 일관 유지.

<br/>

## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #52 

<br/>

## 🧪 테스트 결과
<!-- 코드 검증 시 진행한 테스트 결과에 대한 캡쳐 이미지나 영상 혹은 기타 자료를 첨부해주세요. -->
<!-- 어떤 방식으로 테스트를 진행 하였으며, 왜 그 방식을 채택 했는지에 대한 설명도 작성해주세요. -->
<!-- 성능 테스트 방식이 잘못 되었거나 누락 되어있다면 PR은 거절됩니다. -->
```
2025-10-16T12:44:42.222+09:00  INFO 64008 --- [matching-engine-service] [o-auto-1-exec-2] c.b.M.d.o.service.MatchingEngineService  : LIMIT accepted(no fills): 20251016001 005930 SELL qty=1 price=3500 (fallbackAdded=false)
2025-10-16T12:44:42.268+09:00  INFO 64008 --- [matching-engine-service] [ntainer#4-0-C-1] c.b.M.i.kafka.AllTopicsLoggingConsumer   : [KAFKA/ORDER-STATUS] topic=order-status p=2 off=19 orderId=20251016001 status=NEW_ACCEPTED ticker=005930 side=SELL remaining=1 price=3500 notional=0 ts=1760586282136
2025-10-16T12:44:49.279+09:00  INFO 64008 --- [matching-engine-service] [o-auto-1-exec-3] c.b.M.d.o.service.MatchingEngineService  : LIMIT accepted(no fills): 20251016002 005930 SELL qty=1 price=4000 (fallbackAdded=false)
2025-10-16T12:44:49.287+09:00  INFO 64008 --- [matching-engine-service] [ntainer#4-0-C-1] c.b.M.i.kafka.AllTopicsLoggingConsumer   : [KAFKA/ORDER-STATUS] topic=order-status p=2 off=20 orderId=20251016002 status=NEW_ACCEPTED ticker=005930 side=SELL remaining=1 price=4000 notional=0 ts=1760586289278
2025-10-16T12:45:06.954+09:00  INFO 64008 --- [matching-engine-service] [o-auto-1-exec-4] c.b.M.d.o.service.MatchingEngineService  : MARKET partial: 20251016003 ticker=005930 side=BUY remainingUnits=2
2025-10-16T12:45:06.964+09:00  INFO 64008 --- [matching-engine-service] [ntainer#3-0-C-1] c.b.M.i.kafka.AllTopicsLoggingConsumer   : [KAFKA/EXECUTIONS] topic=executions p=2 off=7 tradeId=20251016003-20251016001-0c386324-f9a4-4924-86d9-ee94a029482e orderId=20251016003 counterOrderId=20251016001 ticker=005930 side=BUY qty=1 price=3500 ts=1760586306945
2025-10-16T12:45:06.971+09:00  INFO 64008 --- [matching-engine-service] [ntainer#4-0-C-1] c.b.M.i.kafka.AllTopicsLoggingConsumer   : [KAFKA/ORDER-STATUS] topic=order-status p=2 off=21 orderId=20251016003 status=MARKET_PARTIAL ticker=005930 side=BUY remaining=2 price=6000 notional=7500 ts=1760586306954
2025-10-16T12:45:06.977+09:00  INFO 64008 --- [matching-engine-service] [ntainer#3-0-C-1] c.b.M.i.kafka.AllTopicsLoggingConsumer   : [KAFKA/EXECUTIONS] topic=executions p=2 off=8 tradeId=20251016003-20251016002-752906a0-2a67-4aed-8311-ee5bc746fe25 orderId=20251016003 counterOrderId=20251016002 ticker=005930 side=BUY qty=1 price=4000 ts=1760586306954
2025-10-16T12:49:13.158+09:00  INFO 64008 --- [matching-engine-service] [rap-executor-%d] c.n.d.s.r.aws.ConfigClusterResolver      : Resolving eureka endpoints via configuration
```

<br/>

## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
- MatchingEngine에서 발행된 메시지를 컴슘하여 사용하고 있는 서비스 모듈(Ordering, MarketData)은 특히나 더 자세히 확인 부탁드립니다.
<br/>

## 👥 리뷰어 지정
<!-- 반드시 2명 이상 리뷰어를 지정해주세요 -->
<!-- 모든 리뷰어가 PR 리뷰를 마친 뒤 병합을 진행합니다. -->
<!-- 예: @username1 @username2 -->
@jinnn12 @JeaPple 

<br/>

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: Feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.
- [x] 코드에 대한 테스트를 진행 하였으며, 결과에 대한 자료를 첨부하였습니다.
- [x] 최소 2명의 리뷰어를 지정했습니다.