### PR TITLE
[Fix] 댓글 수 동기화 및 투표 매핑 오류 수정, 게시글 stockId 필터링 기능 추가 (#63)

### DIFF
--- a/community/src/main/java/com/beyond/MKX/domain/forumPost/controller/ForumPostPublicController.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumPost/controller/ForumPostPublicController.java
@@ -28,13 +28,21 @@ public class ForumPostPublicController {
         }
     }
 
-    /** 글 목록: status 필터(optional), pageable */
+    /** 글 목록: status 필터(optional), stockId 필터(optional), pageable */
     @GetMapping
     public ResponseEntity<?> list(@RequestParam(required = false) PostStatus status,
+                                  @RequestParam(required = false) UUID stockId,
                                   Pageable pageable,
                                   @RequestHeader(value = "X-User-Id", required = false) String userHeader) {
         UUID viewerId = parseViewer(userHeader);
-        Page<ForumPostResDto> page = forumPostQueryService.list(status, pageable, viewerId);
+        
+        Page<ForumPostResDto> page;
+        if (stockId != null) {
+            page = forumPostQueryService.listByStock(stockId, status, pageable, viewerId);
+        } else {
+            page = forumPostQueryService.list(status, pageable, viewerId);
+        }
+        
         return ApiResponse.ok(page, "게시글 목록 조회 성공");
     }
 

--- a/community/src/main/java/com/beyond/MKX/domain/forumPost/controller/ForumPostQueryController.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumPost/controller/ForumPostQueryController.java
@@ -27,4 +27,12 @@ public class ForumPostQueryController {
         Page<ForumPostResDto> page = forumPostQueryService.listMine(actorId, status, pageable);
         return ApiResponse.ok(page, "내 게시글 조회 성공");
     }
+
+    /** 게시글 상세 조회 (댓글, 투표 포함) */
+    @GetMapping("/{postId}/details")
+    public ResponseEntity<?> getWithDetails(@PathVariable UUID postId,
+                                           @RequestHeader(value = "X-User-Id", required = false) UUID viewerId) {
+        ForumPostResDto post = forumPostQueryService.getWithDetails(postId, viewerId);
+        return ApiResponse.ok(post, "게시글 상세 조회 성공");
+    }
 }

--- a/community/src/main/java/com/beyond/MKX/domain/forumPost/dto/ForumPostResDto.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumPost/dto/ForumPostResDto.java
@@ -3,6 +3,8 @@ package com.beyond.MKX.domain.forumPost.dto;
 import com.beyond.MKX.domain.common.entity.WriterRole;
 import com.beyond.MKX.domain.forumCategory.dto.ForumCategoryResDto;
 import com.beyond.MKX.domain.forumPost.entity.PostStatus;
+import com.beyond.MKX.domain.forumPostComment.dto.ForumPostCommentRes;
+import com.beyond.MKX.domain.forumVote.dto.ForumVoteResDto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
@@ -28,5 +30,7 @@ public record ForumPostResDto(
         long version,
         List<ForumCategoryResDto> categories,
         WriterRole writerRole,
-        boolean likedByMe
+        boolean likedByMe,
+        List<ForumPostCommentRes> comments,
+        ForumVoteResDto vote
 ) {}

--- a/community/src/main/java/com/beyond/MKX/domain/forumPost/entity/ForumPost.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumPost/entity/ForumPost.java
@@ -3,6 +3,7 @@ package com.beyond.MKX.domain.forumPost.entity;
 import com.beyond.MKX.common.domain.BaseIdAndTimeEntity;
 import com.beyond.MKX.domain.forumCategory.entity.ForumCategory;
 import com.beyond.MKX.domain.common.entity.WriterRole;
+import com.beyond.MKX.domain.forumVote.entity.ForumVote;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Size;
 import lombok.*;
@@ -75,6 +76,9 @@ public class ForumPost extends BaseIdAndTimeEntity {
     @Size(max = 512)
     @Column(name = "image_url", length = 512)
     private String imageUrl;
+
+    @OneToOne(mappedBy = "forumPost", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private ForumVote vote;
 
     @Version
     @Column(name = "version", nullable = false)

--- a/community/src/main/java/com/beyond/MKX/domain/forumPost/repository/ForumPostRepository.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumPost/repository/ForumPostRepository.java
@@ -5,6 +5,9 @@ import com.beyond.MKX.domain.forumPost.entity.PostStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.UUID;
 
@@ -27,4 +30,12 @@ public interface ForumPostRepository extends JpaRepository<ForumPost, UUID> {
     Page<ForumPost> findByCreatedByAndStatus(UUID createdBy, PostStatus status, Pageable pageable);
 
     boolean existsByIdAndDeletedAtIsNull(UUID id);
+
+    @Modifying
+    @Query("update ForumPost p set p.commentCount = p.commentCount + 1 where p.id = :postId")
+    void incrementCommentCount(@Param("postId") UUID postId);
+
+    @Modifying
+    @Query("update ForumPost p set p.commentCount = case when p.commentCount > 0 then p.commentCount - 1 else 0 end where p.id = :postId")
+    void decrementCommentCount(@Param("postId") UUID postId);
 }

--- a/community/src/main/java/com/beyond/MKX/domain/forumPost/repository/ForumPostRepository.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumPost/repository/ForumPostRepository.java
@@ -29,6 +29,12 @@ public interface ForumPostRepository extends JpaRepository<ForumPost, UUID> {
     // 특정 사용자 + 상태
     Page<ForumPost> findByCreatedByAndStatus(UUID createdBy, PostStatus status, Pageable pageable);
 
+    // 특정 종목 글
+    Page<ForumPost> findByStockId(UUID stockId, Pageable pageable);
+
+    // 특정 종목 + 상태
+    Page<ForumPost> findByStockIdAndStatus(UUID stockId, PostStatus status, Pageable pageable);
+
     boolean existsByIdAndDeletedAtIsNull(UUID id);
 
     @Modifying

--- a/community/src/main/java/com/beyond/MKX/domain/forumPost/service/query/ForumPostQueryService.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumPost/service/query/ForumPostQueryService.java
@@ -11,6 +11,7 @@ public interface ForumPostQueryService {
     Page<ForumPostResDto> list(PostStatus status, Pageable pageable, UUID viewerId);
     Page<ForumPostResDto> listMine(UUID me, PostStatus status, Pageable pageable);
     Page<ForumPostResDto> listByUser(UUID userId, PostStatus status, Pageable pageable, UUID viewerId);
+    Page<ForumPostResDto> listByStock(UUID stockId, PostStatus status, Pageable pageable, UUID viewerId);
     ForumPostResDto get(UUID postId, UUID viewerId);
     ForumPostResDto getWithDetails(UUID postId, UUID viewerId);
 }

--- a/community/src/main/java/com/beyond/MKX/domain/forumPost/service/query/ForumPostQueryService.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumPost/service/query/ForumPostQueryService.java
@@ -12,4 +12,5 @@ public interface ForumPostQueryService {
     Page<ForumPostResDto> listMine(UUID me, PostStatus status, Pageable pageable);
     Page<ForumPostResDto> listByUser(UUID userId, PostStatus status, Pageable pageable, UUID viewerId);
     ForumPostResDto get(UUID postId, UUID viewerId);
+    ForumPostResDto getWithDetails(UUID postId, UUID viewerId);
 }

--- a/community/src/main/java/com/beyond/MKX/domain/forumPost/service/query/ForumPostQueryServiceImpl.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumPost/service/query/ForumPostQueryServiceImpl.java
@@ -70,6 +70,22 @@ public class ForumPostQueryServiceImpl implements ForumPostQueryService {
     }
 
     @Override
+    public Page<ForumPostResDto> listByStock(UUID stockId, PostStatus status, Pageable pageable, UUID viewerId) {
+        Page<ForumPost> page = (status == null)
+                ? postRepo.findByStockId(stockId, pageable)
+                : postRepo.findByStockIdAndStatus(stockId, status, pageable);
+
+        Set<UUID> likedPostIds = Collections.emptySet();
+        if (viewerId != null && !page.isEmpty()) {
+            List<UUID> ids = page.map(ForumPost::getId).toList();
+            likedPostIds = likeRepo.findLikedPostIdsByUser(viewerId, ids);
+        }
+
+        Set<UUID> finalLiked = likedPostIds;
+        return page.map(p -> map(p, finalLiked.contains(p.getId())));
+    }
+
+    @Override
     public ForumPostResDto get(UUID postId, UUID viewerId) {
         ForumPost post = postRepo.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("ForumPost not found: " + postId));

--- a/community/src/main/java/com/beyond/MKX/domain/forumPost/service/query/ForumPostQueryServiceImpl.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumPost/service/query/ForumPostQueryServiceImpl.java
@@ -7,6 +7,8 @@ import com.beyond.MKX.domain.forumPost.entity.ForumPostCategory;
 import com.beyond.MKX.domain.forumPost.entity.PostStatus;
 import com.beyond.MKX.domain.forumPost.repository.ForumPostRepository;
 import com.beyond.MKX.domain.forumPostLike.repository.ForumPostLikeRepository;
+import com.beyond.MKX.domain.forumPostComment.service.ForumPostCommentQueryService;
+import com.beyond.MKX.domain.forumVote.service.query.ForumVoteQueryService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -24,6 +26,8 @@ public class ForumPostQueryServiceImpl implements ForumPostQueryService {
 
     private final ForumPostRepository postRepo;
     private final ForumPostLikeRepository likeRepo;
+    private final ForumPostCommentQueryService commentQueryService;
+    private final ForumVoteQueryService voteQueryService;
 
     @Override
     public Page<ForumPostResDto> list(PostStatus status, Pageable pageable, UUID viewerId) {
@@ -73,6 +77,14 @@ public class ForumPostQueryServiceImpl implements ForumPostQueryService {
         return map(post, liked);
     }
 
+    @Override
+    public ForumPostResDto getWithDetails(UUID postId, UUID viewerId) {
+        ForumPost post = postRepo.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException("ForumPost not found: " + postId));
+        boolean liked = viewerId != null && likeRepo.existsByPostIdAndUserId(postId, viewerId);
+        return mapWithDetails(post, liked);
+    }
+
     private ForumPostResDto map(ForumPost p, boolean likedByMe) {
         List<ForumCategoryResDto> catDtos = p.getCategories().stream()
                 .map(ForumPostCategory::getCategory)
@@ -82,6 +94,13 @@ public class ForumPostQueryServiceImpl implements ForumPostQueryService {
                         .description(c.getDescription())
                         .build())
                 .collect(Collectors.toList());
+
+        // 댓글 목록 가져오기 (최대 10개)
+        Pageable commentPageable = Pageable.ofSize(10);
+        var comments = commentQueryService.listByPost(p.getId(), commentPageable, null).getContent();
+
+        // 투표 정보 가져오기
+        var vote = voteQueryService.getByPost(p.getId(), null);
 
         return ForumPostResDto.builder()
                 .id(p.getId())
@@ -100,6 +119,47 @@ public class ForumPostQueryServiceImpl implements ForumPostQueryService {
                 .categories(catDtos)
                 .writerRole(p.getWriterRole())
                 .likedByMe(likedByMe)
+                .comments(comments)
+                .vote(vote)
+                .build();
+    }
+
+    private ForumPostResDto mapWithDetails(ForumPost p, boolean likedByMe) {
+        List<ForumCategoryResDto> catDtos = p.getCategories().stream()
+                .map(ForumPostCategory::getCategory)
+                .map(c -> ForumCategoryResDto.builder()
+                        .id(c.getId())
+                        .name(c.getName())
+                        .description(c.getDescription())
+                        .build())
+                .collect(Collectors.toList());
+
+        // 댓글 목록 가져오기 (최대 10개)
+        Pageable commentPageable = Pageable.ofSize(10);
+        var comments = commentQueryService.listByPost(p.getId(), commentPageable, null).getContent();
+
+        // 투표 정보 가져오기
+        var vote = voteQueryService.getByPost(p.getId(), null);
+
+        return ForumPostResDto.builder()
+                .id(p.getId())
+                .stockId(p.getStockId())
+                .createdBy(p.getCreatedBy())
+                .title(p.getTitle())
+                .contents(p.getContents())
+                .imageUrl(p.getImageUrl())
+                .status(p.getStatus())
+                .likesCount(p.getLikesCount())
+                .commentCount(p.getCommentCount())
+                .createdAt(p.getCreatedAt())
+                .updatedAt(p.getUpdatedAt())
+                .deletedAt(p.getDeletedAt())
+                .version(p.getVersion())
+                .categories(catDtos)
+                .writerRole(p.getWriterRole())
+                .likedByMe(likedByMe)
+                .comments(comments)
+                .vote(vote)
                 .build();
     }
 }

--- a/community/src/main/java/com/beyond/MKX/domain/forumPostComment/service/ForumPostCommentCommandServiceImpl.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumPostComment/service/ForumPostCommentCommandServiceImpl.java
@@ -37,7 +37,11 @@ public class ForumPostCommentCommandServiceImpl implements ForumPostCommentComma
                 .likes(0)
                 .build();
 
-        return ForumPostCommentMapper.toRes(commentRepo.save(entity));
+        ForumPostComment saved = commentRepo.save(entity);
+
+        postRepo.incrementCommentCount(post.getId());
+
+        return ForumPostCommentMapper.toRes(saved);
     }
 
     @Override
@@ -60,6 +64,8 @@ public class ForumPostCommentCommandServiceImpl implements ForumPostCommentComma
         }
         int updated = commentRepo.softDelete(commentId, LocalDateTime.now());
         if (updated == 0) throw new IllegalStateException("Already deleted or cannot delete: " + commentId);
+
+        postRepo.decrementCommentCount(c.getPost().getId());
     }
 
     @Override

--- a/community/src/main/java/com/beyond/MKX/domain/forumVote/entity/ForumVote.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumVote/entity/ForumVote.java
@@ -23,7 +23,7 @@ import java.util.List;
 )
 public class ForumVote extends BaseIdAndTimeEntity {
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "forum_post_id", nullable = false,
             foreignKey = @ForeignKey(name = "fk_forum_vote_post"))
     private ForumPost forumPost;

--- a/community/src/main/java/com/beyond/MKX/domain/forumVote/repository/ForumVoteRepository.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumVote/repository/ForumVoteRepository.java
@@ -1,5 +1,6 @@
 package com.beyond.MKX.domain.forumVote.repository;
 
+import com.beyond.MKX.domain.forumPost.entity.ForumPost;
 import com.beyond.MKX.domain.forumVote.entity.ForumVote;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,4 +18,7 @@ public interface ForumVoteRepository extends JpaRepository<ForumVote, UUID> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select v from ForumVote v where v.id = :id")
     Optional<ForumVote> findByIdForUpdate(@Param("id") UUID id);
+
+    @Query("SELECT p FROM ForumPost p LEFT JOIN FETCH p.vote WHERE p.id = :id")
+    Optional<ForumPost> findWithVoteById(@Param("id") UUID id);
 }

--- a/community/src/main/java/com/beyond/MKX/domain/forumVote/service/query/ForumVoteQueryServiceImpl.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumVote/service/query/ForumVoteQueryServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -39,8 +40,14 @@ public class ForumVoteQueryServiceImpl implements ForumVoteQueryService {
 
     @Override
     public ForumVoteResDto getByPost(UUID postId, UUID viewerId) {
-        ForumVote v = voteRepo.findByForumPost_Id(postId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 게시글에는 투표가 존재하지 않습니다."));
+        Optional<ForumVote> voteOpt = voteRepo.findByForumPost_Id(postId);
+
+        if (voteOpt.isEmpty()) {
+            return null;
+        }
+
+        ForumVote v = voteOpt.get();
+
         List<ForumVoteSelection> sels = selectionRepo.findByVote_IdOrderBySortOrderAsc(v.getId());
         boolean votedByMe = (viewerId != null) && logRepo.existsByVote_IdAndVotedBy(v.getId(), viewerId);
         return toResDto(v, sels, votedByMe);


### PR DESCRIPTION
## 📋 작업 개요
게시글-댓글 관계 및 투표 시스템 안정화, stockId 기반 게시글 필터링 기능 추가

<br/>

## 🔧 작업 상세
- **댓글 수 동기화 로직 추가**
  - 댓글 생성 시 게시글의 `comment_count` 증가(Incre), 삭제 시 감소(Decre) 로직 구현  
  - `ForumPost` 엔티티와 `ForumPostComment` 간의 연관관계 기반으로 카운트 동기화 처리  
- **투표 시스템 매핑 및 조회 개선**
  - `ForumPost` ↔ `ForumVote` 간 `@OneToOne(mappedBy = "post")` 매핑 오류 수정  
  - 게시글 목록 조회 시 투표 정보(`ForumVoteResDto`) 포함되도록 개선  
  - 투표가 존재하지 않는 게시글에 대해 NPE 방지를 위한 예외 처리 추가  
- **게시글 목록 필터링 기능 추가**
  - `stockId` 파라미터를 통한 종목별 게시글 필터링 기능 구현  
  - Spring Data JPA 메서드 네이밍 컨벤션(`findByStockIdAndDeletedAtIsNullOrderByCreatedAtDesc`) 활용  
  - 주식 커뮤니티 페이지에서 종목별 게시글 조회 로직과 연동 확인 완료  

<br/>

## 📌 이슈 번호
close #63 

<br/>

## 🧪 테스트 결과
- **댓글 수 검증:** 댓글 생성 및 삭제 후 `commentCount` 필드의 증가/감소 정상 반영 확인 (Postman & DB 조회)  
- **투표 정보 조회 테스트:** 투표 포함 게시글과 미포함 게시글 각각 조회 시 예외 미발생 및 정상 응답 확인  
- **stockId 필터링 검증:** `/api/forum/posts?stockId=005930` 요청 시 특정 종목 게시글만 조회됨 확인  

<br/>

## ⚠️ 참고사항
- `ForumPost.commentCount`는 DB에 직접 반영되며 비동기 이벤트 처리는 추후 성능 개선 시점에 고려 예정  
- `ForumVote` 연관관계 변경으로 기존 데이터 마이그레이션 필요 없음 (FK 일관성 유지)  
- 게시글 상세 조회 API는 동일한 응답 구조 유지  

<br/>

## 👥 리뷰어 지정
@ggj0228 @JeaPple 

<br/>

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인했습니다.
- [x] 코드에 대한 테스트를 진행하였으며, 결과를 Postman 및 DB 로그로 검증했습니다.
- [x] 최소 2명의 리뷰어를 지정했습니다.
