### PR TITLE
[Feat, Fix] 포럼 백앤드 세부 사항 수정 임시 PR (#76)

### DIFF
--- a/community/src/main/java/com/beyond/MKX/domain/forumPost/service/query/ForumPostQueryServiceImpl.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumPost/service/query/ForumPostQueryServiceImpl.java
@@ -42,7 +42,7 @@ public class ForumPostQueryServiceImpl implements ForumPostQueryService {
         }
 
         Set<UUID> finalLiked = likedPostIds;
-        return page.map(p -> map(p, finalLiked.contains(p.getId())));
+        return page.map(p -> map(p, finalLiked.contains(p.getId()), viewerId));
     }
 
     @Override
@@ -50,7 +50,7 @@ public class ForumPostQueryServiceImpl implements ForumPostQueryService {
         Page<ForumPost> page = (status == null)
                 ? postRepo.findByCreatedBy(me, pageable)
                 : postRepo.findByCreatedByAndStatus(me, status, pageable);
-        return page.map(p -> map(p, false));
+        return page.map(p -> map(p, false, null));
     }
 
     @Override
@@ -66,7 +66,7 @@ public class ForumPostQueryServiceImpl implements ForumPostQueryService {
         }
 
         Set<UUID> finalLiked = likedPostIds;
-        return page.map(p -> map(p, finalLiked.contains(p.getId())));
+        return page.map(p -> map(p, finalLiked.contains(p.getId()), viewerId));
     }
 
     @Override
@@ -82,7 +82,7 @@ public class ForumPostQueryServiceImpl implements ForumPostQueryService {
         }
 
         Set<UUID> finalLiked = likedPostIds;
-        return page.map(p -> map(p, finalLiked.contains(p.getId())));
+        return page.map(p -> map(p, finalLiked.contains(p.getId()), viewerId));
     }
 
     @Override
@@ -90,7 +90,7 @@ public class ForumPostQueryServiceImpl implements ForumPostQueryService {
         ForumPost post = postRepo.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("ForumPost not found: " + postId));
         boolean liked = viewerId != null && likeRepo.existsByPostIdAndUserId(postId, viewerId);
-        return map(post, liked);
+        return map(post, liked, viewerId);
     }
 
     @Override
@@ -98,10 +98,10 @@ public class ForumPostQueryServiceImpl implements ForumPostQueryService {
         ForumPost post = postRepo.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("ForumPost not found: " + postId));
         boolean liked = viewerId != null && likeRepo.existsByPostIdAndUserId(postId, viewerId);
-        return mapWithDetails(post, liked);
+        return mapWithDetails(post, liked, viewerId);
     }
 
-    private ForumPostResDto map(ForumPost p, boolean likedByMe) {
+    private ForumPostResDto map(ForumPost p, boolean likedByMe, UUID viewerId) {
         List<ForumCategoryResDto> catDtos = p.getCategories().stream()
                 .map(ForumPostCategory::getCategory)
                 .map(c -> ForumCategoryResDto.builder()
@@ -113,7 +113,7 @@ public class ForumPostQueryServiceImpl implements ForumPostQueryService {
 
         // 댓글 목록 가져오기 (최대 10개)
         Pageable commentPageable = Pageable.ofSize(10);
-        var comments = commentQueryService.listByPost(p.getId(), commentPageable, null).getContent();
+        var comments = commentQueryService.listByPost(p.getId(), commentPageable, viewerId).getContent();
 
         // 투표 정보 가져오기
         var vote = voteQueryService.getByPost(p.getId(), null);
@@ -140,7 +140,7 @@ public class ForumPostQueryServiceImpl implements ForumPostQueryService {
                 .build();
     }
 
-    private ForumPostResDto mapWithDetails(ForumPost p, boolean likedByMe) {
+    private ForumPostResDto mapWithDetails(ForumPost p, boolean likedByMe, UUID viewerId) {
         List<ForumCategoryResDto> catDtos = p.getCategories().stream()
                 .map(ForumPostCategory::getCategory)
                 .map(c -> ForumCategoryResDto.builder()
@@ -152,7 +152,7 @@ public class ForumPostQueryServiceImpl implements ForumPostQueryService {
 
         // 댓글 목록 가져오기 (최대 10개)
         Pageable commentPageable = Pageable.ofSize(10);
-        var comments = commentQueryService.listByPost(p.getId(), commentPageable, null).getContent();
+        var comments = commentQueryService.listByPost(p.getId(), commentPageable, viewerId).getContent();
 
         // 투표 정보 가져오기
         var vote = voteQueryService.getByPost(p.getId(), null);


### PR DESCRIPTION
- ForumPostQueryServiceImpl의 map 메서드에 viewerId 파라미터 추가
- 댓글 조회 시 viewerId를 commentQueryService에 전달하여 좋아요 상태 정확히 계산
- 게시물과 댓글의 likedByMe 상태가 일관되게 처리되도록 개선

## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  

<br/>

## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  

<br/>

## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  

<br/>

## 🧪 테스트 결과
<!-- 코드 검증 시 진행한 테스트 결과에 대한 캡쳐 이미지나 영상 혹은 기타 자료를 첨부해주세요. -->
<!-- 어떤 방식으로 테스트를 진행 하였으며, 왜 그 방식을 채택 했는지에 대한 설명도 작성해주세요. -->
<!-- 성능 테스트 방식이 잘못 되었거나 누락 되어있다면 PR은 거절됩니다. -->

<br/>

## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  

<br/>

## 👥 리뷰어 지정
<!-- 반드시 2명 이상 리뷰어를 지정해주세요 -->
<!-- 모든 리뷰어가 PR 리뷰를 마친 뒤 병합을 진행합니다. -->
<!-- 예: @username1 @username2 -->

<br/>

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: Feat: 테이블 등록 기능 구현 -->
- [ ] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.
- [ ] 코드에 대한 테스트를 진행 하였으며, 결과에 대한 자료를 첨부하였습니다.
- [ ] 최소 2명의 리뷰어를 지정했습니다.