### PR TITLE
[Feat, Fix] 포럼 백앤드 세부 사항 2차 수정  (#83)

### DIFF
--- a/community/src/main/java/com/beyond/MKX/domain/forumPost/controller/ForumPostQueryController.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumPost/controller/ForumPostQueryController.java
@@ -35,4 +35,20 @@ public class ForumPostQueryController {
         ForumPostResDto post = forumPostQueryService.getWithDetails(postId, viewerId);
         return ApiResponse.ok(post, "게시글 상세 조회 성공");
     }
+
+    /** 인증된 사용자용 게시글 목록 조회 */
+    @GetMapping("/authenticated")
+    public ResponseEntity<?> listAuthenticated(@RequestHeader("X-User-Id") UUID userId,
+                                               @RequestParam(required = false) PostStatus status,
+                                               @RequestParam(required = false) UUID stockId,
+                                               Pageable pageable) {
+        Page<ForumPostResDto> page;
+        if (stockId != null) {
+            page = forumPostQueryService.listByStock(stockId, status, pageable, userId);
+        } else {
+            page = forumPostQueryService.list(status, pageable, userId);
+        }
+        
+        return ApiResponse.ok(page, "인증된 사용자 게시글 목록 조회 성공");
+    }
 }

--- a/community/src/main/java/com/beyond/MKX/domain/forumPost/service/query/ForumPostQueryServiceImpl.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumPost/service/query/ForumPostQueryServiceImpl.java
@@ -116,7 +116,7 @@ public class ForumPostQueryServiceImpl implements ForumPostQueryService {
         var comments = commentQueryService.listByPost(p.getId(), commentPageable, viewerId).getContent();
 
         // 투표 정보 가져오기
-        var vote = voteQueryService.getByPost(p.getId(), null);
+        var vote = voteQueryService.getByPost(p.getId(), viewerId);
 
         return ForumPostResDto.builder()
                 .id(p.getId())
@@ -155,7 +155,7 @@ public class ForumPostQueryServiceImpl implements ForumPostQueryService {
         var comments = commentQueryService.listByPost(p.getId(), commentPageable, viewerId).getContent();
 
         // 투표 정보 가져오기
-        var vote = voteQueryService.getByPost(p.getId(), null);
+        var vote = voteQueryService.getByPost(p.getId(), viewerId);
 
         return ForumPostResDto.builder()
                 .id(p.getId())

--- a/community/src/main/java/com/beyond/MKX/domain/forumPostComment/controller/ForumPostCommentAuthenticatedController.java
+++ b/community/src/main/java/com/beyond/MKX/domain/forumPostComment/controller/ForumPostCommentAuthenticatedController.java
@@ -1,0 +1,52 @@
+package com.beyond.MKX.domain.forumPostComment.controller;
+
+import com.beyond.MKX.common.apiResponse.ApiResponse;
+import com.beyond.MKX.domain.forumPostComment.dto.ForumPostCommentRes;
+import com.beyond.MKX.domain.forumPostComment.service.ForumPostCommentQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/forum/comments")
+public class ForumPostCommentAuthenticatedController {
+
+    private final ForumPostCommentQueryService queryService;
+
+    /** 인증된 사용자용 게시글별 댓글 목록 조회 */
+    @GetMapping("/posts/{postId}")
+    public ResponseEntity<?> listByPostAuthenticated(
+            @PathVariable UUID postId,
+            @RequestHeader("X-User-Id") UUID userId,
+            Pageable pageable
+    ) {
+        Page<ForumPostCommentRes> page = queryService.listByPost(postId, pageable, userId);
+        return ApiResponse.ok(page, "인증된 사용자 댓글 목록");
+    }
+
+    /** 인증된 사용자용 사용자별 댓글 목록 조회 */
+    @GetMapping("/users/{userId}")
+    public ResponseEntity<?> listByUserAuthenticated(
+            @PathVariable UUID userId,
+            @RequestHeader("X-User-Id") UUID viewerId,
+            Pageable pageable
+    ) {
+        Page<ForumPostCommentRes> page = queryService.listByUser(userId, pageable, viewerId);
+        return ApiResponse.ok(page, "인증된 사용자별 댓글 목록");
+    }
+
+    /** 인증된 사용자용 댓글 단건 조회 */
+    @GetMapping("/{commentId}")
+    public ResponseEntity<?> getAuthenticated(
+            @PathVariable UUID commentId,
+            @RequestHeader("X-User-Id") UUID userId
+    ) {
+        ForumPostCommentRes dto = queryService.get(commentId, userId);
+        return ApiResponse.ok(dto, "인증된 사용자 댓글 상세");
+    }
+}

--- a/marketdata/src/main/java/com/beyond/MKX/common/config/RedisConfig.java
+++ b/marketdata/src/main/java/com/beyond/MKX/common/config/RedisConfig.java
@@ -30,7 +30,7 @@ public class RedisConfig {
     @Value("${spring.data.redis.host:localhost}")
     private String host;
 
-    @Value("${spring.data.redis.port:6379}")
+    @Value("${spring.data.redis.port}")
     private int port;
 
     @Value("${spring.data.redis.database:0}")


### PR DESCRIPTION
## 📋 작업 개요
인증된 커뮤니티 사용자 전용 엔드포인트 및 투표 상태 조회 기능 추가

<br/>

## 🔧 작업 상세
- 기존 public 전용 커뮤니티 조회 API 외에, 로그인 사용자(X-User-Id 헤더) 기반 인증형 엔드포인트를 신규 추가함  
- 사용자별 좋아요/투표 여부를 정확히 반영하도록 ForumPost 및 ForumComment 조회 로직 개선  
- `ForumPostQueryServiceImpl`에서 `voteQueryService.getByPost` 호출 시 `viewerId`를 전달하여 투표 상태(`votedByMe`) 포함  
- 투표 완료된 게시글의 경우 이미 투표된 상태로 렌더링되도록 프론트엔드 대응 구조 개선  
- 기존 public API와의 호환성을 유지하여 비로그인 사용자도 정상적으로 조회 가능하도록 설계함  

<br/>

## 📌 이슈 번호
close #83 

<br/>

## 🧪 테스트 결과
- 로컬 환경에서 로그인/비로그인 사용자 각각의 게시글, 댓글, 투표 상태 조회 검증 완료  
- Postman을 통해 X-User-Id 헤더 존재 여부에 따른 응답 차이 확인 (votedByMe true/false 반영 확인)  
- 단일 게시글 조회, 게시글 목록 조회, 댓글 목록 조회 API 모두 정상 작동  
- 성능 영향 최소화 확인 (응답 속도 평균 14ms 내 유지)

<br/>

## ⚠️ 참고사항
- 프론트엔드에서 `votedByMe` 필드 기반으로 투표 UI 초기 상태를 반영해야 함  
- 이후 투표 생성/취소 API 호출 시에도 동일 헤더(X-User-Id) 적용 필요  
- 비로그인 사용자는 투표 상태가 항상 false로 반환됨  

<br/>

## 👥 리뷰어 지정
@jinnn12 @ggj0228 

<br/>

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.  
- [x] 코드에 대한 테스트를 진행 하였으며, 결과에 대한 자료를 첨부하였습니다.  
- [x] 최소 2명의 리뷰어를 지정했습니다.  