### PR TITLE
[Feat] 상장폐지 단계 정보 및 보상 조회 기능 추가 (#98)

### DIFF
--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/delisting/controller/DelistingCompensationController.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/delisting/controller/DelistingCompensationController.java
@@ -1,0 +1,62 @@
+package com.beyond.MKX.domain.delisting.controller;
+
+import com.beyond.MKX.common.apiResponse.ApiResponse;
+import com.beyond.MKX.domain.delisting.entity.DelistingCompensation;
+import com.beyond.MKX.domain.delisting.repository.DelistingCompensationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/delisting/compensation")
+@RequiredArgsConstructor
+public class DelistingCompensationController {
+
+    private final DelistingCompensationRepository compensationRepository;
+
+    /**
+     * 주식별 보상 목록 조회
+     */
+    @GetMapping("/stock/{stockId}")
+    public ResponseEntity<?> getCompensationByStock(@PathVariable UUID stockId, 
+                                                    @RequestParam(value = "includeDeleted", defaultValue = "false") boolean includeDeleted) {
+        List<DelistingCompensation> compensation;
+        if (includeDeleted) {
+            compensation = compensationRepository.findAllByStockId(stockId);
+        } else {
+            compensation = compensationRepository.findByStockId(stockId);
+        }
+        return ApiResponse.ok(compensation, "주식별 보상 목록 조회 성공");
+    }
+
+    /**
+     * 회원별 보상 목록 조회
+     */
+    @GetMapping("/member/{memberAccountId}")
+    public ResponseEntity<?> getCompensationByMember(@PathVariable UUID memberAccountId) {
+        List<DelistingCompensation> compensation = compensationRepository.findByMemberAccountId(memberAccountId);
+        return ApiResponse.ok(compensation, "회원별 보상 목록 조회 성공");
+    }
+
+    /**
+     * 상태별 보상 목록 조회
+     */
+    @GetMapping("/status/{status}")
+    public ResponseEntity<?> getCompensationByStatus(@PathVariable com.beyond.MKX.domain.delisting.entity.CompensationStatus status) {
+        List<DelistingCompensation> compensation = compensationRepository.findByStatus(status);
+        return ApiResponse.ok(compensation, "상태별 보상 목록 조회 성공");
+    }
+
+    /**
+     * 대기 중인 보상 목록 조회
+     */
+    @GetMapping("/pending")
+    public ResponseEntity<?> getPendingCompensations() {
+        List<DelistingCompensation> compensation = compensationRepository.findPendingCompensations();
+        return ApiResponse.ok(compensation, "대기 중인 보상 목록 조회 성공");
+    }
+}
+

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/delisting/controller/DelistingHistoryController.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/delisting/controller/DelistingHistoryController.java
@@ -1,0 +1,47 @@
+package com.beyond.MKX.domain.delisting.controller;
+
+import com.beyond.MKX.common.apiResponse.ApiResponse;
+import com.beyond.MKX.domain.delisting.entity.DelistingHistory;
+import com.beyond.MKX.domain.delisting.repository.DelistingHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/delisting/history")
+@RequiredArgsConstructor
+public class DelistingHistoryController {
+
+    private final DelistingHistoryRepository historyRepository;
+
+    /**
+     * 주식별 상장폐지 이력 조회
+     */
+    @GetMapping("/stock/{stockId}")
+    public ResponseEntity<?> getHistoryByStock(@PathVariable UUID stockId) {
+        List<DelistingHistory> history = historyRepository.findByStockId(stockId);
+        return ApiResponse.ok(history, "주식별 상장폐지 이력 조회 성공");
+    }
+
+    /**
+     * 액션 유형별 이력 조회
+     */
+    @GetMapping("/action-type/{actionType}")
+    public ResponseEntity<?> getHistoryByActionType(@PathVariable com.beyond.MKX.domain.delisting.entity.ActionType actionType) {
+        List<DelistingHistory> history = historyRepository.findByActionType(actionType);
+        return ApiResponse.ok(history, "액션 유형별 이력 조회 성공");
+    }
+
+    /**
+     * 실행자별 이력 조회
+     */
+    @GetMapping("/executed-by/{executedBy}")
+    public ResponseEntity<?> getHistoryByExecutedBy(@PathVariable UUID executedBy) {
+        List<DelistingHistory> history = historyRepository.findByExecutedBy(executedBy);
+        return ApiResponse.ok(history, "실행자별 이력 조회 성공");
+    }
+}
+

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/delisting/repository/DelistingCompensationRepository.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/delisting/repository/DelistingCompensationRepository.java
@@ -11,10 +11,16 @@ import java.util.UUID;
 public interface DelistingCompensationRepository extends JpaRepository<DelistingCompensation, UUID> {
 
     /**
-     * 주식별 보상 목록 조회
+     * 주식별 보상 목록 조회 (삭제되지 않은 것만)
+     */
+    @Query("SELECT dc FROM DelistingCompensation dc WHERE dc.stockId = :stockId AND dc.deletedAt IS NULL ORDER BY dc.requestedAt DESC")
+    List<DelistingCompensation> findByStockId(@Param("stockId") UUID stockId);
+    
+    /**
+     * 주식별 모든 보상 목록 조회 (삭제된 것 포함)
      */
     @Query("SELECT dc FROM DelistingCompensation dc WHERE dc.stockId = :stockId ORDER BY dc.requestedAt DESC")
-    List<DelistingCompensation> findByStockId(@Param("stockId") UUID stockId);
+    List<DelistingCompensation> findAllByStockId(@Param("stockId") UUID stockId);
 
     /**
      * 회원별 보상 목록 조회

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/stock/dto/StockListResDto.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/stock/dto/StockListResDto.java
@@ -13,6 +13,7 @@ public record StockListResDto(
         String ticker,
         String nameKo,
         String status,
+        String delistingStage,
         long totalSharesOutstanding,
         Long ownedShares,
         Long freeFloatShares,
@@ -27,6 +28,7 @@ public record StockListResDto(
                 .ticker(s.getTicker())
                 .nameKo(s.getNameKo())
                 .status(s.getStatus() != null ? s.getStatus().name() : null)
+                .delistingStage(s.getDelistingStage() != null ? s.getDelistingStage().name() : null)
                 .totalSharesOutstanding(s.getTotalSharesOutstanding())
                 .ownedShares(s.getOwnedShares())
                 .freeFloatShares(s.getFreeFloatShares())

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/stock/repository/StockRepository.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/stock/repository/StockRepository.java
@@ -54,4 +54,23 @@ public interface StockRepository extends JpaRepository<Stock, UUID> {
      * 여러 상태의 주식 목록 조회 (자동화용)
      */
     List<Stock> findByStatusIn(List<Status> statuses);
+
+    /**
+     * 특정 상태를 제외한 주식 목록 조회
+     */
+    @Query("""
+            select s
+            from Stock s
+            where (:excludeStatus is null or s.status != :excludeStatus)
+              and (
+                   :q is null
+                or lower(s.ticker)  like lower(concat('%', :q, '%'))
+                or lower(s.nameKo)  like lower(concat('%', :q, '%'))
+              )
+            """)
+    Page<Stock> searchExcludingStatus(
+            @Param("excludeStatus") Status excludeStatus,
+            @Param("q") String q,
+            Pageable pageable
+    );
 }

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/stock/service/StockQueryService.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/stock/service/StockQueryService.java
@@ -17,11 +17,24 @@ public class StockQueryService {
 
     public Page<StockListResDto> getStocks(String q, String status, Pageable pageable) {
         Stock.Status statusEnum = null;
+        Stock.Status excludeStatus = null;
+        
         if (status != null && !status.isBlank()) {
-            statusEnum = Stock.Status.valueOf(status.toUpperCase());
+            // DELISTED 제외 요청 처리 (!DELISTED)
+            if (status.equalsIgnoreCase("!DELISTED")) {
+                excludeStatus = Stock.Status.DELISTED;
+            } else {
+                statusEnum = Stock.Status.valueOf(status.toUpperCase());
+            }
         }
 
-        Page<Stock> page = stockRepository.search(statusEnum, emptyToNull(q), pageable);
+        Page<Stock> page;
+        if (excludeStatus != null) {
+            page = stockRepository.searchExcludingStatus(excludeStatus, emptyToNull(q), pageable);
+        } else {
+            page = stockRepository.search(statusEnum, emptyToNull(q), pageable);
+        }
+        
         return page.map(StockListResDto::from);
     }
 


### PR DESCRIPTION
## 📋 작업 개요
상장폐지 단계 정보 및 보상 조회 기능을 추가하여 종목/회원/상태 기반의 세분화된 데이터 접근을 지원함.  

<br/>

## 🔧 작업 상세
- **종목 목록 API 확장**
  - `StockListResDto`에 `delistingStage` 필드 추가 → 각 종목의 상장폐지 단계를 클라이언트로 반환  
  - `searchExcludingStatus` 메서드 추가 → 특정 상태를 제외한 종목 검색 가능  
  - `'!DELISTED'` 파라미터 처리 로직 구현 → 상장폐지 종목 제외 조회 지원  

- **상장폐지 보상 조회 API 엔드포인트 추가**
  - `/api/delisting/compensation/stock/{stockId}` : 주식별 보상 목록 조회 (삭제된 항목 포함 여부 옵션 지원)  
  - `/api/delisting/compensation/member/{memberAccountId}` : 회원별 보상 목록 조회  
  - `/api/delisting/compensation/status/{status}` : 상태별 보상 목록 조회  
  - `/api/delisting/compensation/pending` : 대기 중인 보상 목록 조회  

- **중복 커밋 병합 및 코드 구조 개선**
  - 보상 조회 API 관련 중복 커밋 통합 및 불필요한 중복 로직 제거  
  - 엔드포인트별 컨트롤러 메서드 명세 및 Swagger 문서화 완료  

<br/>

## 📌 이슈 번호
close #98 

<br/>

## 🧪 테스트 결과
- Postman을 이용하여 각 보상 조회 엔드포인트 호출 테스트 완료  
- Stock API에서 `!DELISTED` 파라미터 적용 시 정상적으로 상장폐지 종목 제외 확인  
- 삭제된 보상 항목 포함 여부 옵션(`includeDeleted`)에 따라 필터링 동작 정상 확인  
- 상태별 보상 조회 및 대기 보상 목록이 DB 데이터와 일치함을 검증  
- JPA Repository 테스트를 통해 `searchExcludingStatus` 메서드의 정확성 확인 완료  

<br/>

## ⚠️ 참고사항
- 추후 상장폐지 보상 API에 Pagination 및 정렬 옵션 추가 예정  
- 관리자 페이지 연동 시 상태별 보상 데이터 모니터링 기능으로 확장 가능  

<br/>

## 👥 리뷰어 지정
@AstroJini @ggj0228 

<br/>

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.  
- [x] 코드에 대한 테스트를 진행하였으며, 결과에 대한 자료를 첨부하였습니다.  
- [x] 최소 2명의 리뷰어를 지정했습니다.  