### PR TITLE
[Feat] 자금 흐름 기본 로직 구현 (#103)

### DIFF
--- a/mkx-platform/build.gradle
+++ b/mkx-platform/build.gradle
@@ -53,6 +53,10 @@ dependencies {
 
 	// msa간에 통신을 위한 openfeign의존성 추가
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	
+	// Kafka 의존성
+	implementation 'org.springframework.kafka:spring-kafka'
+	implementation 'org.apache.kafka:kafka-clients'
 
 	// 401처리 위함
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/mkx-platform/src/main/java/com/beyond/MKX/common/kafka/config/KafkaProducerConfig.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/common/kafka/config/KafkaProducerConfig.java
@@ -1,0 +1,48 @@
+package com.beyond.MKX.common.kafka.config;
+
+import com.beyond.MKX.common.kafka.event.TransactionEvent;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Kafka Producer 설정
+ * 
+ * - TransactionEvent 발행을 위한 ProducerFactory 및 KafkaTemplate 설정
+ */
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    /**
+     * TransactionEvent 전용 ProducerFactory
+     */
+    @Bean
+    public ProducerFactory<String, TransactionEvent> transactionProducerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    /**
+     * TransactionEvent 전용 KafkaTemplate
+     */
+    @Bean
+    public KafkaTemplate<String, TransactionEvent> transactionKafkaTemplate() {
+        return new KafkaTemplate<>(transactionProducerFactory());
+    }
+}
+

--- a/mkx-platform/src/main/java/com/beyond/MKX/common/kafka/event/TransactionEvent.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/common/kafka/event/TransactionEvent.java
@@ -1,0 +1,29 @@
+package com.beyond.MKX.common.kafka.event;
+
+import lombok.*;
+
+/**
+ * 입출금 거래 이벤트
+ * 
+ * 사용처
+ * - 입금/출금 발생 시 Kafka "transaction-events" 토픽으로 전송하는 페이로드 모델
+ * - ordering-service가 이를 컨슘하여 Ledger에 기록
+ */
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class TransactionEvent {
+    private String eventId;              // 멱등성 키
+    private String accountNumber;        // 계좌번호
+    private String accountId;            // 계좌 UUID (MEMBER: MemberAccount.id, CORPORATION: CorporationAccount.id)
+    private String accountType;          // MEMBER, CORPORATION, BROKERAGE, EXCHANGE
+    private String transactionType;      // DEPOSIT, WITHDRAWAL
+    private Long amount;                 // 거래 금액
+    private String method;               // 거래 방법 (BANK_TRANSFER, CARD 등) - optional
+    private String description;          // 거래 설명 - optional
+    private Long timestamp;              // 이벤트 발생 시각
+}
+

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/account/corporation/service/CorporationAccountService.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/account/corporation/service/CorporationAccountService.java
@@ -24,6 +24,7 @@ public class CorporationAccountService {
 
     private final CorporationAccountRepository repository;
     private final AccountListService accountListService;
+    private final TransactionEventPublisher eventPublisher;
 
     /** 기업이 계좌 등록 요청
      *  - 스키마(FK 제약)상 corporation_account.account_number 는 account_list.account_number 를 참조하므로
@@ -105,6 +106,10 @@ public class CorporationAccountService {
             throw new IllegalStateException("기업 계좌가 승인(APPROVED) 상태가 아닙니다.");
         }
         acc.deposit(amount);
+        
+        // Kafka 이벤트 발행
+        eventPublisher.publishDepositEvent(acc.getId().toString(), acc.getAccountNumber(), amount.longValue(), "BANK_TRANSFER");
+        
         return acc.getBalance();
     }
 
@@ -115,6 +120,10 @@ public class CorporationAccountService {
             throw new IllegalStateException("기업 계좌가 승인(APPROVED) 상태가 아닙니다.");
         }
         acc.withdraw(amount);
+        
+        // Kafka 이벤트 발행
+        eventPublisher.publishWithdrawalEvent(acc.getId().toString(), acc.getAccountNumber(), amount.longValue(), "BANK_TRANSFER");
+        
         return acc.getBalance();
     }
 

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/account/corporation/service/TransactionEventPublisher.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/account/corporation/service/TransactionEventPublisher.java
@@ -1,0 +1,72 @@
+package com.beyond.MKX.domain.account.corporation.service;
+
+import com.beyond.MKX.common.kafka.event.TransactionEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+/**
+ * 입출금 거래 이벤트 발행 서비스 (CORPORATION)
+ * 
+ * - CORPORATION 계좌의 입금/출금 이벤트를 Kafka로 발행
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class TransactionEventPublisher {
+    
+    private final KafkaTemplate<String, TransactionEvent> transactionKafkaTemplate;
+    private static final String TOPIC = "transaction-events";
+
+    /**
+     * 입금 이벤트 발행
+     * 
+     * @param accountId 계좌 UUID
+     * @param accountNumber 계좌번호
+     * @param amount 거래 금액
+     * @param method 거래 방법
+     */
+    public void publishDepositEvent(String accountId, String accountNumber, Long amount, String method) {
+        TransactionEvent event = TransactionEvent.builder()
+                .eventId(UUID.randomUUID().toString())
+                .accountNumber(accountNumber)
+                .accountId(accountId)
+                .accountType("CORPORATION")
+                .transactionType("DEPOSIT")
+                .amount(amount)
+                .method(method)
+                .timestamp(System.currentTimeMillis())
+                .build();
+        
+        transactionKafkaTemplate.send(TOPIC, accountNumber, event);
+        log.info("입금 이벤트 발행: accountNumber={}, accountId={}, amount={}", accountNumber, accountId, amount);
+    }
+
+    /**
+     * 출금 이벤트 발행
+     * 
+     * @param accountId 계좌 UUID
+     * @param accountNumber 계좌번호
+     * @param amount 거래 금액
+     * @param method 거래 방법
+     */
+    public void publishWithdrawalEvent(String accountId, String accountNumber, Long amount, String method) {
+        TransactionEvent event = TransactionEvent.builder()
+                .eventId(UUID.randomUUID().toString())
+                .accountNumber(accountNumber)
+                .accountId(accountId)
+                .accountType("CORPORATION")
+                .transactionType("WITHDRAWAL")
+                .amount(amount)
+                .method(method)
+                .timestamp(System.currentTimeMillis())
+                .build();
+        
+        transactionKafkaTemplate.send(TOPIC, accountNumber, event);
+        log.info("출금 이벤트 발행: accountNumber={}, accountId={}, amount={}", accountNumber, accountId, amount);
+    }
+}
+

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/member/controller/MemberInternalController.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/member/controller/MemberInternalController.java
@@ -64,4 +64,19 @@ public class MemberInternalController {
                 brokerage.getStatus().name()
         ));
     }
+
+    /**
+     * 회원 이름 조회
+     *
+     * 계좌 이체 등에서 계좌 소유자의 이름을 확인할 때 사용합니다.
+     *
+     * @param memberId 회원 UUID
+     * @return { "name": "회원 이름" }
+     */
+    @GetMapping("/{memberId}/name")
+    public ResponseEntity<?> getMemberName(@PathVariable UUID memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원 없음"));
+        return ResponseEntity.ok(Map.of("name", member.getName()));
+    }
 }

--- a/ordering/src/main/java/com/beyond/MKX/common/kafka/config/KafkaConsumeConfig.java
+++ b/ordering/src/main/java/com/beyond/MKX/common/kafka/config/KafkaConsumeConfig.java
@@ -3,6 +3,7 @@ package com.beyond.MKX.common.kafka.config;
 //import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.beyond.MKX.common.kafka.event.ExecutionEvent;
 import com.beyond.MKX.common.kafka.event.OrderStatusEvent;
+import com.beyond.MKX.common.kafka.event.TransactionEvent;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -70,6 +71,16 @@ public class KafkaConsumeConfig {
     }
 
     // ----------------------------------------------------------------------
+    // transaction-events 전용 ConsumerFactory (TransactionEvent)
+    // ----------------------------------------------------------------------
+    @Bean
+    public ConsumerFactory<String, TransactionEvent> transactionConsumerFactory(KafkaProperties properties) {
+        Map<String, Object> configs = baseConsumerConfigs(properties);
+        configs.put(JsonDeserializer.VALUE_DEFAULT_TYPE, TransactionEvent.class.getName());
+        return new DefaultKafkaConsumerFactory<>(configs);
+    }
+
+    // ----------------------------------------------------------------------
     // 문자열 전용 ConsumerFactory (에러/보조 토픽 등)
     //  - 단순 문자열 수신이므로 ErrorHandlingDeserializer 생략
     // ----------------------------------------------------------------------
@@ -105,6 +116,19 @@ public class KafkaConsumeConfig {
         ConcurrentKafkaListenerContainerFactory<String, OrderStatusEvent> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(orderStatusConsumerFactory);
+        factory.setCommonErrorHandler(commonErrorHandler());
+        // yml의 enable-auto-commit: false 설정에 따른 수동 커밋 설정
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
+        return factory;
+    }
+
+    @Bean("kafkaTransactionListenerFactory")
+    public ConcurrentKafkaListenerContainerFactory<String, TransactionEvent> kafkaTransactionListenerFactory(
+            ConsumerFactory<String, TransactionEvent> transactionConsumerFactory
+    ) {
+        ConcurrentKafkaListenerContainerFactory<String, TransactionEvent> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(transactionConsumerFactory);
         factory.setCommonErrorHandler(commonErrorHandler());
         // yml의 enable-auto-commit: false 설정에 따른 수동 커밋 설정
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);

--- a/ordering/src/main/java/com/beyond/MKX/common/kafka/config/KafkaProducerConfig.java
+++ b/ordering/src/main/java/com/beyond/MKX/common/kafka/config/KafkaProducerConfig.java
@@ -1,0 +1,48 @@
+package com.beyond.MKX.common.kafka.config;
+
+import com.beyond.MKX.common.kafka.event.TransactionEvent;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Kafka Producer 설정
+ * 
+ * - TransactionEvent 발행을 위한 ProducerFactory 및 KafkaTemplate 설정
+ */
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    /**
+     * TransactionEvent 전용 ProducerFactory
+     */
+    @Bean
+    public ProducerFactory<String, TransactionEvent> transactionProducerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    /**
+     * TransactionEvent 전용 KafkaTemplate
+     */
+    @Bean
+    public KafkaTemplate<String, TransactionEvent> transactionKafkaTemplate() {
+        return new KafkaTemplate<>(transactionProducerFactory());
+    }
+}
+

--- a/ordering/src/main/java/com/beyond/MKX/common/kafka/event/TransactionEvent.java
+++ b/ordering/src/main/java/com/beyond/MKX/common/kafka/event/TransactionEvent.java
@@ -20,10 +20,14 @@ public class TransactionEvent {
     private String accountNumber;        // 계좌번호
     private String accountId;            // 계좌 UUID (MEMBER: MemberAccount.id, CORPORATION: CorporationAccount.id)
     private String accountType;          // MEMBER, CORPORATION, BROKERAGE, EXCHANGE
-    private String transactionType;      // DEPOSIT, WITHDRAWAL
+    private String transactionType;      // DEPOSIT, WITHDRAWAL, TRANSFER
     private Long amount;                 // 거래 금액
-    private String method;               // 거래 방법 (BANK_TRANSFER, CARD 등) - optional
+    private String method;               // 거래 방법 (BANK_TRANSFER, CARD, TRANSFER 등) - optional
     private String description;          // 거래 설명 - optional
     private Long timestamp;              // 이벤트 발생 시각
+    
+    // 계좌이체 시 상대방 정보
+    private String counterpartyAccountNumber;  // 상대방 계좌번호
+    private String counterpartyName;           // 상대방 이름
 }
 

--- a/ordering/src/main/java/com/beyond/MKX/common/kafka/event/TransactionEvent.java
+++ b/ordering/src/main/java/com/beyond/MKX/common/kafka/event/TransactionEvent.java
@@ -1,0 +1,29 @@
+package com.beyond.MKX.common.kafka.event;
+
+import lombok.*;
+
+/**
+ * 입출금 거래 이벤트
+ * 
+ * 사용처
+ * - 입금/출금 발생 시 Kafka "transaction-events" 토픽으로 전송하는 페이로드 모델
+ * - ordering-service가 이를 컨슘하여 Ledger에 기록
+ */
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class TransactionEvent {
+    private String eventId;              // 멱등성 키
+    private String accountNumber;        // 계좌번호
+    private String accountId;            // 계좌 UUID (MEMBER: MemberAccount.id, CORPORATION: CorporationAccount.id)
+    private String accountType;          // MEMBER, CORPORATION, BROKERAGE, EXCHANGE
+    private String transactionType;      // DEPOSIT, WITHDRAWAL
+    private Long amount;                 // 거래 금액
+    private String method;               // 거래 방법 (BANK_TRANSFER, CARD 등) - optional
+    private String description;          // 거래 설명 - optional
+    private Long timestamp;              // 이벤트 발생 시각
+}
+

--- a/ordering/src/main/java/com/beyond/MKX/domain/account/member/client/MemberInternalClient.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/account/member/client/MemberInternalClient.java
@@ -29,4 +29,13 @@ public interface MemberInternalClient {
      */
     @GetMapping("/api/internal/members/{memberId}/context")
     MemberContextRes getContext(@PathVariable("memberId") UUID memberId);
+
+    /**
+     * 회원 이름 조회
+     *
+     * @param memberId 회원 UUID
+     * @return Map { "name": "회원 이름" }
+     */
+    @GetMapping("/api/internal/members/{memberId}/name")
+    java.util.Map<String, String> getMemberName(@PathVariable("memberId") UUID memberId);
 }

--- a/ordering/src/main/java/com/beyond/MKX/domain/account/member/controller/MemberAccountController.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/account/member/controller/MemberAccountController.java
@@ -4,6 +4,8 @@ import com.beyond.MKX.common.apiResponse.ApiResponse;
 import com.beyond.MKX.domain.account.member.service.IdempotencyService;
 import com.beyond.MKX.domain.account.member.dto.MemberAccountCreateRes;
 import com.beyond.MKX.domain.account.member.dto.AmountRequest;
+import com.beyond.MKX.domain.account.member.dto.TransferRequest;
+import com.beyond.MKX.domain.account.member.dto.AccountInfoResponse;
 import com.beyond.MKX.domain.account.member.dto.MemberContextRes;
 import com.beyond.MKX.domain.account.member.service.MemberAccountService;
 import com.beyond.MKX.domain.account.member.client.MemberInternalClient;
@@ -209,5 +211,61 @@ public class MemberAccountController {
         }
         Long balance = service.withdraw(accountNumber, req.getAmount());
         return ApiResponse.ok(Map.of("balance", balance), "출금 완료");
+    }
+
+    /**
+     * 계좌 이체 (회원 본인만)
+     * 헤더 요구: X-User-Role=MEMBER, X-User-Id=<회원 UUID>
+     * - 송금인 본인 계좌 여부 검증
+     * - 수취인 계좌 존재 여부 자동 검증
+     */
+    @PostMapping("/{fromAccountNumber}/transfer")
+    public ResponseEntity<?> transfer(
+            @RequestHeader(value = "X-User-Role", required = false) String role,
+            @RequestHeader(value = "X-User-Id", required = false) String memberId,
+            @PathVariable String fromAccountNumber,
+            @RequestBody TransferRequest req
+    ) throws AuthenticationException {
+        if (role == null || !"MEMBER".equalsIgnoreCase(role)) {
+            throw new AuthenticationException("회원만 접근 가능합니다.");
+        }
+        if (memberId == null || memberId.isBlank()) {
+            throw new AuthenticationException("X-User-Id 헤더가 없습니다.");
+        }
+        
+        // 송금인 본인 계좌 여부 검증
+        MemberAccount fromAcc = service.getByAccountNumber(fromAccountNumber);
+        if (!fromAcc.getMemberId().equals(UUID.fromString(memberId))) {
+            throw new AuthenticationException("본인 계좌가 아닙니다.");
+        }
+        
+        // 이체 실행
+        service.transfer(fromAccountNumber, req.getToAccountNumber(), req.getAmount());
+        
+        // 이체 후 잔액 조회
+        MemberAccount updatedAcc = service.getByAccountNumber(fromAccountNumber);
+        return ApiResponse.ok(Map.of("balance", updatedAcc.getBalance()), "이체 완료");
+    }
+
+    /**
+     * 계좌 정보 조회 (계좌번호로 소유자 확인)
+     * - 모든 로그인 사용자가 조회 가능 (이체 시 수취인 확인용)
+     * - 현재는 계좌 존재 여부만 확인 (추후 이름 조회 기능 추가 가능)
+     */
+    @GetMapping("/info/{accountNumber}")
+    public ResponseEntity<?> getAccountInfo(@PathVariable String accountNumber) {
+        MemberAccount acc = service.getByAccountNumber(accountNumber);
+        
+        // 회원 ID를 마스킹하여 일부만 표시
+        String memberId = acc.getMemberId().toString();
+        String maskedMemberId = memberId.substring(0, 8) + "****";
+        
+        AccountInfoResponse response = new AccountInfoResponse(
+            accountNumber,
+            "회원 (" + maskedMemberId + ")",  // 임시: 회원 ID 일부만 표시
+            "MEMBER"
+        );
+        
+        return ApiResponse.ok(response, "계좌 정보 조회 성공");
     }
 }

--- a/ordering/src/main/java/com/beyond/MKX/domain/account/member/controller/MemberAccountController.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/account/member/controller/MemberAccountController.java
@@ -11,6 +11,7 @@ import com.beyond.MKX.domain.account.member.service.MemberAccountService;
 import com.beyond.MKX.domain.account.member.client.MemberInternalClient;
 import com.beyond.MKX.domain.assets.entity.MemberAccount;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,6 +33,7 @@ import java.util.UUID;
  * - 멱등성: 회원ID + 증권사ID로 서버가 결정적 키(SHA-256)를 생성해 동시/중복 제출을 흡수한다.
  * - 실제 생성 후 "플랫폼"의 account_list에 메타 데이터를 등록한다.
  */
+@Slf4j
 @RestController
 @RequestMapping("/api/accounts/member")
 @RequiredArgsConstructor
@@ -226,43 +228,79 @@ public class MemberAccountController {
             @PathVariable String fromAccountNumber,
             @RequestBody TransferRequest req
     ) throws AuthenticationException {
-        if (role == null || !"MEMBER".equalsIgnoreCase(role)) {
-            throw new AuthenticationException("회원만 접근 가능합니다.");
-        }
-        if (memberId == null || memberId.isBlank()) {
-            throw new AuthenticationException("X-User-Id 헤더가 없습니다.");
-        }
+        log.info("=== 이체 요청 시작 ===");
+        log.info("fromAccountNumber: {}, toAccountNumber: {}, amount: {}", 
+                fromAccountNumber, req.getToAccountNumber(), req.getAmount());
+        log.info("role: {}, memberId: {}", role, memberId);
         
-        // 송금인 본인 계좌 여부 검증
-        MemberAccount fromAcc = service.getByAccountNumber(fromAccountNumber);
-        if (!fromAcc.getMemberId().equals(UUID.fromString(memberId))) {
-            throw new AuthenticationException("본인 계좌가 아닙니다.");
+        try {
+            if (role == null || !"MEMBER".equalsIgnoreCase(role)) {
+                log.error("권한 불일치: {}", role);
+                throw new AuthenticationException("회원만 접근 가능합니다.");
+            }
+            if (memberId == null || memberId.isBlank()) {
+                log.error("memberId 누락");
+                throw new AuthenticationException("X-User-Id 헤더가 없습니다.");
+            }
+            
+            // 송금인 본인 계좌 여부 검증
+            MemberAccount fromAcc = service.getByAccountNumber(fromAccountNumber);
+            log.info("fromAcc 정보 - memberId: {}, balance: {}, status: {}", 
+                    fromAcc.getMemberId(), fromAcc.getBalance(), fromAcc.getStatus());
+            
+            if (!fromAcc.getMemberId().equals(UUID.fromString(memberId))) {
+                log.error("계좌 소유자 불일치. 계좌 소유자: {}, 요청자: {}", 
+                        fromAcc.getMemberId(), memberId);
+                throw new AuthenticationException("본인 계좌가 아닙니다.");
+            }
+            
+            // 수취인 계좌 확인
+            MemberAccount toAcc = service.getByAccountNumber(req.getToAccountNumber());
+            log.info("toAcc 정보 - memberId: {}, balance: {}, status: {}", 
+                    toAcc.getMemberId(), toAcc.getBalance(), toAcc.getStatus());
+            
+            // 이체 실행
+            log.info("이체 실행 시작...");
+            service.transfer(fromAccountNumber, req.getToAccountNumber(), req.getAmount());
+            log.info("이체 실행 완료");
+            
+            // 이체 후 잔액 조회
+            MemberAccount updatedAcc = service.getByAccountNumber(fromAccountNumber);
+            log.info("이체 후 잔액: {}", updatedAcc.getBalance());
+            log.info("=== 이체 요청 성공 ===");
+            
+            return ApiResponse.ok(Map.of("balance", updatedAcc.getBalance()), "이체 완료");
+        } catch (Exception e) {
+            log.error("=== 이체 실패 ===");
+            log.error("에러 메시지: {}", e.getMessage());
+            log.error("에러 타입: {}", e.getClass().getName());
+            log.error("스택 트레이스:", e);
+            throw e;
         }
-        
-        // 이체 실행
-        service.transfer(fromAccountNumber, req.getToAccountNumber(), req.getAmount());
-        
-        // 이체 후 잔액 조회
-        MemberAccount updatedAcc = service.getByAccountNumber(fromAccountNumber);
-        return ApiResponse.ok(Map.of("balance", updatedAcc.getBalance()), "이체 완료");
     }
 
     /**
      * 계좌 정보 조회 (계좌번호로 소유자 확인)
      * - 모든 로그인 사용자가 조회 가능 (이체 시 수취인 확인용)
-     * - 현재는 계좌 존재 여부만 확인 (추후 이름 조회 기능 추가 가능)
+     * - 회원 이름을 mkx-platform에서 조회하여 반환
      */
     @GetMapping("/info/{accountNumber}")
     public ResponseEntity<?> getAccountInfo(@PathVariable String accountNumber) {
         MemberAccount acc = service.getByAccountNumber(accountNumber);
         
-        // 회원 ID를 마스킹하여 일부만 표시
-        String memberId = acc.getMemberId().toString();
-        String maskedMemberId = memberId.substring(0, 8) + "****";
+        // 회원 이름 조회
+        String memberName;
+        try {
+            Map<String, String> nameResponse = memberInternalClient.getMemberName(acc.getMemberId());
+            memberName = nameResponse.get("name");
+        } catch (Exception e) {
+            // Feign 호출 실패 시 fallback
+            memberName = "회원";
+        }
         
         AccountInfoResponse response = new AccountInfoResponse(
             accountNumber,
-            "회원 (" + maskedMemberId + ")",  // 임시: 회원 ID 일부만 표시
+            memberName,
             "MEMBER"
         );
         

--- a/ordering/src/main/java/com/beyond/MKX/domain/account/member/dto/AccountInfoResponse.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/account/member/dto/AccountInfoResponse.java
@@ -1,0 +1,15 @@
+package com.beyond.MKX.domain.account.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccountInfoResponse {
+    private String accountNumber;
+    private String accountHolderName;  // 계좌 소유자 이름
+    private String accountType;        // MEMBER, CORPORATION, BROKERAGE, EXCHANGE
+}
+

--- a/ordering/src/main/java/com/beyond/MKX/domain/account/member/dto/TransferRequest.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/account/member/dto/TransferRequest.java
@@ -1,0 +1,21 @@
+package com.beyond.MKX.domain.account.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TransferRequest {
+    @NotBlank(message = "수취인 계좌번호는 필수입니다.")
+    private String toAccountNumber;
+    
+    @NotNull(message = "이체 금액은 필수입니다.")
+    @Positive(message = "이체 금액은 양수여야 합니다.")
+    private Long amount;
+}
+

--- a/ordering/src/main/java/com/beyond/MKX/domain/account/member/service/MemberAccountService.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/account/member/service/MemberAccountService.java
@@ -8,6 +8,7 @@ import com.beyond.MKX.domain.assets.entity.AccountStatus;
 import com.beyond.MKX.domain.assets.entity.MemberAccount;
 import com.beyond.MKX.domain.assets.repository.MemberAccountRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
@@ -23,6 +24,7 @@ import java.util.UUID;
  * - 생성 후 mkx-platform(account_list)에 MEMBER 유형으로 메타 등록 요청(Feign)
  * - 계좌번호 충돌 회피(여러 번 시도)
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -159,26 +161,48 @@ public class MemberAccountService {
      * - 트랜잭션으로 묶어서 처리
      */
     public void transfer(String fromAccountNumber, String toAccountNumber, Long amount) {
+        log.info(">>> Service.transfer 시작");
+        log.info("fromAccountNumber: {}, toAccountNumber: {}, amount: {}", 
+                fromAccountNumber, toAccountNumber, amount);
+        
         // 송금인 계좌 검증 및 출금
         MemberAccount fromAcc = getByAccountNumber(fromAccountNumber);
+        log.info("송금인 계좌 조회 완료 - status: {}, balance: {}", 
+                fromAcc.getStatus(), fromAcc.getBalance());
+        
         if (fromAcc.getStatus() != AccountStatus.ACTIVE) {
+            log.error("송금인 계좌 상태 불일치: {}", fromAcc.getStatus());
             throw new IllegalStateException("송금인 계좌 상태가 활성(ACTIVE)이 아닙니다.");
         }
         
         // 수취인 계좌 검증
         MemberAccount toAcc = getByAccountNumber(toAccountNumber);
+        log.info("수취인 계좌 조회 완료 - status: {}, balance: {}", 
+                toAcc.getStatus(), toAcc.getBalance());
+        
         if (toAcc.getStatus() != AccountStatus.ACTIVE) {
+            log.error("수취인 계좌 상태 불일치: {}", toAcc.getStatus());
             throw new IllegalStateException("수취인 계좌 상태가 활성(ACTIVE)이 아닙니다.");
         }
         
         // 송금인 출금
+        log.info("송금인 출금 시작: {} 원", amount);
         fromAcc.withdraw(amount);
+        log.info("송금인 출금 완료 - 남은 잔액: {}", fromAcc.getBalance());
         
         // 수취인 입금
+        log.info("수취인 입금 시작: {} 원", amount);
         toAcc.deposit(amount);
+        log.info("수취인 입금 완료 - 현재 잔액: {}", toAcc.getBalance());
         
         // Kafka 이벤트 발행 (출금/입금 각각)
+        log.info("Kafka 이벤트 발행 시작");
         eventPublisher.publishWithdrawalEvent(fromAccountNumber, fromAcc.getId(), amount, "TRANSFER");
+        log.info("출금 이벤트 발행 완료");
+        
         eventPublisher.publishDepositEvent(toAccountNumber, toAcc.getId(), amount, "TRANSFER");
+        log.info("입금 이벤트 발행 완료");
+        
+        log.info(">>> Service.transfer 완료");
     }
 }

--- a/ordering/src/main/java/com/beyond/MKX/domain/account/member/service/MemberAccountService.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/account/member/service/MemberAccountService.java
@@ -151,4 +151,34 @@ public class MemberAccountService {
         
         return acc.getBalance();
     }
+
+    /**
+     * 계좌 이체: MEMBER 계좌 간 이체
+     * - 송금인 계좌에서 출금
+     * - 수취인 계좌로 입금
+     * - 트랜잭션으로 묶어서 처리
+     */
+    public void transfer(String fromAccountNumber, String toAccountNumber, Long amount) {
+        // 송금인 계좌 검증 및 출금
+        MemberAccount fromAcc = getByAccountNumber(fromAccountNumber);
+        if (fromAcc.getStatus() != AccountStatus.ACTIVE) {
+            throw new IllegalStateException("송금인 계좌 상태가 활성(ACTIVE)이 아닙니다.");
+        }
+        
+        // 수취인 계좌 검증
+        MemberAccount toAcc = getByAccountNumber(toAccountNumber);
+        if (toAcc.getStatus() != AccountStatus.ACTIVE) {
+            throw new IllegalStateException("수취인 계좌 상태가 활성(ACTIVE)이 아닙니다.");
+        }
+        
+        // 송금인 출금
+        fromAcc.withdraw(amount);
+        
+        // 수취인 입금
+        toAcc.deposit(amount);
+        
+        // Kafka 이벤트 발행 (출금/입금 각각)
+        eventPublisher.publishWithdrawalEvent(fromAccountNumber, fromAcc.getId(), amount, "TRANSFER");
+        eventPublisher.publishDepositEvent(toAccountNumber, toAcc.getId(), amount, "TRANSFER");
+    }
 }

--- a/ordering/src/main/java/com/beyond/MKX/domain/account/member/service/MemberAccountService.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/account/member/service/MemberAccountService.java
@@ -1,6 +1,7 @@
 package com.beyond.MKX.domain.account.member.service;
 
 import com.beyond.MKX.domain.account.member.client.AccountListClient;
+import com.beyond.MKX.domain.account.member.client.MemberInternalClient;
 import com.beyond.MKX.domain.account.member.dto.AccountListRegisterReq;
 import com.beyond.MKX.domain.account.member.dto.AccountStatusUpdateReq;
 import com.beyond.MKX.domain.account.member.util.MemberAccountNumberGenerator;
@@ -33,6 +34,7 @@ public class MemberAccountService {
     private final MemberAccountRepository repository;
     private final AccountListClient accountListClient;
     private final TransactionEventPublisher eventPublisher;
+    private final MemberInternalClient memberInternalClient;
 
     /**
      * 수동 생성(계좌번호 지정)
@@ -185,6 +187,11 @@ public class MemberAccountService {
             throw new IllegalStateException("수취인 계좌 상태가 활성(ACTIVE)이 아닙니다.");
         }
         
+        // 송금인/수취인 이름 조회
+        String fromName = getMemberName(fromAcc.getMemberId());
+        String toName = getMemberName(toAcc.getMemberId());
+        log.info("이름 조회 완료 - 송금인: {}, 수취인: {}", fromName, toName);
+        
         // 송금인 출금
         log.info("송금인 출금 시작: {} 원", amount);
         fromAcc.withdraw(amount);
@@ -195,14 +202,28 @@ public class MemberAccountService {
         toAcc.deposit(amount);
         log.info("수취인 입금 완료 - 현재 잔액: {}", toAcc.getBalance());
         
-        // Kafka 이벤트 발행 (출금/입금 각각)
+        // Kafka 이벤트 발행 (이체 전용 이벤트, 상대방 정보 포함)
         log.info("Kafka 이벤트 발행 시작");
-        eventPublisher.publishWithdrawalEvent(fromAccountNumber, fromAcc.getId(), amount, "TRANSFER");
-        log.info("출금 이벤트 발행 완료");
+        eventPublisher.publishTransferWithdrawalEvent(
+            fromAccountNumber, fromAcc.getId(), amount, toAccountNumber, toName);
+        log.info("이체 출금 이벤트 발행 완료");
         
-        eventPublisher.publishDepositEvent(toAccountNumber, toAcc.getId(), amount, "TRANSFER");
-        log.info("입금 이벤트 발행 완료");
+        eventPublisher.publishTransferDepositEvent(
+            toAccountNumber, toAcc.getId(), amount, fromAccountNumber, fromName);
+        log.info("이체 입금 이벤트 발행 완료");
         
         log.info(">>> Service.transfer 완료");
+    }
+    
+    /**
+     * 회원 이름 조회 (Feign 호출)
+     */
+    private String getMemberName(UUID memberId) {
+        try {
+            return memberInternalClient.getMemberName(memberId).get("name");
+        } catch (Exception e) {
+            log.warn("회원 이름 조회 실패: memberId={}, error={}", memberId, e.getMessage());
+            return "회원";
+        }
     }
 }

--- a/ordering/src/main/java/com/beyond/MKX/domain/account/member/service/MemberAccountService.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/account/member/service/MemberAccountService.java
@@ -30,6 +30,7 @@ public class MemberAccountService {
 
     private final MemberAccountRepository repository;
     private final AccountListClient accountListClient;
+    private final TransactionEventPublisher eventPublisher;
 
     /**
      * 수동 생성(계좌번호 지정)
@@ -128,6 +129,10 @@ public class MemberAccountService {
             throw new IllegalStateException("계좌 상태가 활성(ACTIVE)이 아닙니다.");
         }
         acc.deposit(amount);
+        
+        // Kafka 이벤트 발행
+        eventPublisher.publishDepositEvent(accountNumber, acc.getId(), amount, "BANK_TRANSFER");
+        
         return acc.getBalance();
     }
 
@@ -140,6 +145,10 @@ public class MemberAccountService {
             throw new IllegalStateException("계좌 상태가 활성(ACTIVE)이 아닙니다.");
         }
         acc.withdraw(amount);
+        
+        // Kafka 이벤트 발행
+        eventPublisher.publishWithdrawalEvent(accountNumber, acc.getId(), amount, "BANK_TRANSFER");
+        
         return acc.getBalance();
     }
 }

--- a/ordering/src/main/java/com/beyond/MKX/domain/account/member/service/TransactionEventPublisher.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/account/member/service/TransactionEventPublisher.java
@@ -1,0 +1,72 @@
+package com.beyond.MKX.domain.account.member.service;
+
+import com.beyond.MKX.common.kafka.event.TransactionEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+/**
+ * 입출금 거래 이벤트 발행 서비스
+ * 
+ * - MEMBER 계좌의 입금/출금 이벤트를 Kafka로 발행
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class TransactionEventPublisher {
+    
+    private final KafkaTemplate<String, TransactionEvent> transactionKafkaTemplate;
+    private static final String TOPIC = "transaction-events";
+
+    /**
+     * 입금 이벤트 발행
+     * 
+     * @param accountNumber 계좌번호
+     * @param accountId 계좌 UUID
+     * @param amount 거래 금액
+     * @param method 거래 방법
+     */
+    public void publishDepositEvent(String accountNumber, UUID accountId, Long amount, String method) {
+        TransactionEvent event = TransactionEvent.builder()
+                .eventId(UUID.randomUUID().toString())
+                .accountNumber(accountNumber)
+                .accountId(accountId != null ? accountId.toString() : null)
+                .accountType("MEMBER")
+                .transactionType("DEPOSIT")
+                .amount(amount)
+                .method(method)
+                .timestamp(System.currentTimeMillis())
+                .build();
+        
+        transactionKafkaTemplate.send(TOPIC, accountNumber, event);
+        log.info("입금 이벤트 발행: accountNumber={}, accountId={}, amount={}", accountNumber, accountId, amount);
+    }
+
+    /**
+     * 출금 이벤트 발행
+     * 
+     * @param accountNumber 계좌번호
+     * @param accountId 계좌 UUID
+     * @param amount 거래 금액
+     * @param method 거래 방법
+     */
+    public void publishWithdrawalEvent(String accountNumber, UUID accountId, Long amount, String method) {
+        TransactionEvent event = TransactionEvent.builder()
+                .eventId(UUID.randomUUID().toString())
+                .accountNumber(accountNumber)
+                .accountId(accountId != null ? accountId.toString() : null)
+                .accountType("MEMBER")
+                .transactionType("WITHDRAWAL")
+                .amount(amount)
+                .method(method)
+                .timestamp(System.currentTimeMillis())
+                .build();
+        
+        transactionKafkaTemplate.send(TOPIC, accountNumber, event);
+        log.info("출금 이벤트 발행: accountNumber={}, accountId={}, amount={}", accountNumber, accountId, amount);
+    }
+}
+

--- a/ordering/src/main/java/com/beyond/MKX/domain/account/member/service/TransactionEventPublisher.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/account/member/service/TransactionEventPublisher.java
@@ -68,5 +68,63 @@ public class TransactionEventPublisher {
         transactionKafkaTemplate.send(TOPIC, accountNumber, event);
         log.info("출금 이벤트 발행: accountNumber={}, accountId={}, amount={}", accountNumber, accountId, amount);
     }
+
+    /**
+     * 계좌이체 출금 이벤트 발행 (상대방 정보 포함)
+     * 
+     * @param accountNumber 송금인 계좌번호
+     * @param accountId 송금인 계좌 UUID
+     * @param amount 이체 금액
+     * @param counterpartyAccountNumber 수취인 계좌번호
+     * @param counterpartyName 수취인 이름
+     */
+    public void publishTransferWithdrawalEvent(String accountNumber, UUID accountId, Long amount,
+                                                String counterpartyAccountNumber, String counterpartyName) {
+        TransactionEvent event = TransactionEvent.builder()
+                .eventId(UUID.randomUUID().toString())
+                .accountNumber(accountNumber)
+                .accountId(accountId != null ? accountId.toString() : null)
+                .accountType("MEMBER")
+                .transactionType("TRANSFER")
+                .amount(amount)
+                .method("TRANSFER_WITHDRAWAL")  // 출금임을 명시
+                .counterpartyAccountNumber(counterpartyAccountNumber)
+                .counterpartyName(counterpartyName)
+                .timestamp(System.currentTimeMillis())
+                .build();
+        
+        transactionKafkaTemplate.send(TOPIC, accountNumber, event);
+        log.info("이체 출금 이벤트 발행: accountNumber={}, counterparty={} ({}), amount={}", 
+                accountNumber, counterpartyName, counterpartyAccountNumber, amount);
+    }
+
+    /**
+     * 계좌이체 입금 이벤트 발행 (상대방 정보 포함)
+     * 
+     * @param accountNumber 수취인 계좌번호
+     * @param accountId 수취인 계좌 UUID
+     * @param amount 이체 금액
+     * @param counterpartyAccountNumber 송금인 계좌번호
+     * @param counterpartyName 송금인 이름
+     */
+    public void publishTransferDepositEvent(String accountNumber, UUID accountId, Long amount,
+                                             String counterpartyAccountNumber, String counterpartyName) {
+        TransactionEvent event = TransactionEvent.builder()
+                .eventId(UUID.randomUUID().toString())
+                .accountNumber(accountNumber)
+                .accountId(accountId != null ? accountId.toString() : null)
+                .accountType("MEMBER")
+                .transactionType("TRANSFER")
+                .amount(amount)
+                .method("TRANSFER_DEPOSIT")  // 입금임을 명시
+                .counterpartyAccountNumber(counterpartyAccountNumber)
+                .counterpartyName(counterpartyName)
+                .timestamp(System.currentTimeMillis())
+                .build();
+        
+        transactionKafkaTemplate.send(TOPIC, accountNumber, event);
+        log.info("이체 입금 이벤트 발행: accountNumber={}, counterparty={} ({}), amount={}", 
+                accountNumber, counterpartyName, counterpartyAccountNumber, amount);
+    }
 }
 

--- a/ordering/src/main/java/com/beyond/MKX/domain/execution/controller/LedgerController.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/execution/controller/LedgerController.java
@@ -1,0 +1,43 @@
+package com.beyond.MKX.domain.execution.controller;
+
+import com.beyond.MKX.common.apiResponse.ApiResponse;
+import com.beyond.MKX.domain.execution.dto.LedgerResponseDTO;
+import com.beyond.MKX.domain.execution.service.LedgerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/ledgers")
+@RequiredArgsConstructor
+public class LedgerController {
+    private final LedgerService ledgerService;
+
+    /**
+     * 특정 계좌의 거래내역을 조회합니다.
+     * 
+     * @param memberAccountId 계좌 ID
+     * @param page 페이지 번호 (기본값: 0)
+     * @param size 페이지 크기 (기본값: 20)
+     * @param type 거래 유형 필터 (BUY, SELL, DEPOSIT, WITHDRAWAL 등)
+     * @return 거래내역 페이지
+     */
+    @GetMapping("/my-account/{memberAccountId}")
+    public ResponseEntity<?> getMyLedgers(
+            @PathVariable UUID memberAccountId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) String type) {
+        
+        Page<LedgerResponseDTO> ledgers = ledgerService.getMyLedgers(memberAccountId, page, size, type);
+        return ApiResponse.ok(ledgers, "거래내역 조회 성공");
+    }
+}
+

--- a/ordering/src/main/java/com/beyond/MKX/domain/execution/dto/LedgerResponseDTO.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/execution/dto/LedgerResponseDTO.java
@@ -1,0 +1,58 @@
+package com.beyond.MKX.domain.execution.dto;
+
+import com.beyond.MKX.domain.execution.entity.Ledger;
+import com.beyond.MKX.domain.execution.entity.TransactionType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LedgerResponseDTO {
+    private UUID id;
+    private String ticker;
+    private String stockName;
+    private TransactionType transactionType;
+    private String transactionTypeKorean;
+    private Long quantity;
+    private Long price;
+    private Long totalAmount;
+    private Long commission;
+    private Long tax;
+    private Long netAmount;
+    private LocalDateTime transactionDate;
+
+    /**
+     * Ledger 엔티티를 LedgerResponseDTO로 변환합니다.
+     * 종목명(stockName)은 별도로 Feign을 통해 조회해야 합니다.
+     */
+    public static LedgerResponseDTO from(Ledger ledger, String stockName) {
+        // 거래 방향 계산: 매수는 음수 금액(debit), 매도는 양수 금액
+        // 매수: 실제 지출 금액 (debit)
+        // 매도: 실제 수취 금액 (credit)
+        long netAmount = ledger.getDebit() != null ? ledger.getDebit() : ledger.getCredit();
+        
+        return LedgerResponseDTO.builder()
+                .id(ledger.getId())
+                .ticker(ledger.getTicker())
+                .stockName(stockName)
+                .transactionType(ledger.getTransactionType())
+                .transactionTypeKorean(ledger.getTransactionType() != null 
+                    ? ledger.getTransactionType().getKoreanName() : "")
+                .quantity(ledger.getQtyChange())
+                .price(ledger.getAmountChange())
+                .totalAmount(ledger.getCredit() != null ? ledger.getCredit() : 0L)
+                .commission(ledger.getCommission())
+                .tax(ledger.getTax() != null ? ledger.getTax() : 0L)
+                .netAmount(netAmount)
+                .transactionDate(ledger.getCreatedAt())
+                .build();
+    }
+}
+

--- a/ordering/src/main/java/com/beyond/MKX/domain/execution/dto/LedgerResponseDTO.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/execution/dto/LedgerResponseDTO.java
@@ -27,6 +27,14 @@ public class LedgerResponseDTO {
     private Long tax;
     private Long netAmount;
     private LocalDateTime transactionDate;
+    
+    // 차변/대변 (이체 입출금 구분용)
+    private Long debit;
+    private Long credit;
+    
+    // 계좌이체 시 상대방 정보
+    private String counterpartyAccountNumber;
+    private String counterpartyName;
 
     /**
      * Ledger 엔티티를 LedgerResponseDTO로 변환합니다.
@@ -52,6 +60,10 @@ public class LedgerResponseDTO {
                 .tax(ledger.getTax() != null ? ledger.getTax() : 0L)
                 .netAmount(netAmount)
                 .transactionDate(ledger.getCreatedAt())
+                .debit(ledger.getDebit())
+                .credit(ledger.getCredit())
+                .counterpartyAccountNumber(ledger.getCounterpartyAccountNumber())
+                .counterpartyName(ledger.getCounterpartyName())
                 .build();
     }
 }

--- a/ordering/src/main/java/com/beyond/MKX/domain/execution/entity/Ledger.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/execution/entity/Ledger.java
@@ -3,8 +3,8 @@ package com.beyond.MKX.domain.execution.entity;
 import com.beyond.MKX.common.domain.BaseIdAndTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -53,5 +53,10 @@ public class Ledger extends BaseIdAndTimeEntity {
     private Long commission;
 
     private Long tax;
+
+    // 거래 유형
+    @Enumerated(EnumType.STRING)
+    @Column(name = "transaction_type", length = 20)
+    private TransactionType transactionType;
 
 }

--- a/ordering/src/main/java/com/beyond/MKX/domain/execution/entity/Ledger.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/execution/entity/Ledger.java
@@ -20,16 +20,13 @@ import java.util.UUID;
 @Entity
 public class Ledger extends BaseIdAndTimeEntity {
 
-    @Column(nullable = false)
     private UUID orderLogId;
 
-    @Column(nullable = false)
     private UUID creditAccountId;
 
-    @Column(nullable = false)
     private UUID debitAccountId;
 
-    @Column(nullable = false, columnDefinition = "VARCHAR(6)")
+    @Column(nullable = true, columnDefinition = "VARCHAR(6)")
     private String ticker;
 
     // 정산일
@@ -42,14 +39,11 @@ public class Ledger extends BaseIdAndTimeEntity {
     private Long credit;
 
     // 거래량
-    @Column(nullable = false)
     private Long qtyChange;
 
     // 거래 가격
-    @Column(nullable = false)
     private Long amountChange;
 
-    @Column(nullable = false)
     private Long commission;
 
     private Long tax;

--- a/ordering/src/main/java/com/beyond/MKX/domain/execution/entity/Ledger.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/execution/entity/Ledger.java
@@ -53,4 +53,12 @@ public class Ledger extends BaseIdAndTimeEntity {
     @Column(name = "transaction_type", length = 20)
     private TransactionType transactionType;
 
+    // 계좌이체 시 상대방 계좌번호
+    @Column(name = "counterparty_account_number", length = 50)
+    private String counterpartyAccountNumber;
+
+    // 계좌이체 시 상대방 이름 (회원명 또는 기업명)
+    @Column(name = "counterparty_name", length = 100)
+    private String counterpartyName;
+
 }

--- a/ordering/src/main/java/com/beyond/MKX/domain/execution/entity/TransactionType.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/execution/entity/TransactionType.java
@@ -1,0 +1,16 @@
+package com.beyond.MKX.domain.execution.entity;
+
+/**
+ * 거래 유형을 나타내는 enum
+ */
+public enum TransactionType {
+    BUY,              // 매수
+    SELL,             // 매도
+    ORDER_REFUND,     // 주문 환불
+    DELISTING_REFUND, // 상장폐지 환불
+    IPO_PARTICIPATE,  // 공모 참가
+    IPO_REFUND,       // 공모 환불
+    IPO_ADDITIONAL,   // 공모 추가 납입
+    DEPOSIT,          // 입금
+    WITHDRAWAL        // 출금
+}

--- a/ordering/src/main/java/com/beyond/MKX/domain/execution/entity/TransactionType.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/execution/entity/TransactionType.java
@@ -12,7 +12,8 @@ public enum TransactionType {
     IPO_REFUND("공모 환불"),
     IPO_ADDITIONAL("공모 추가 납입"),
     DEPOSIT("입금"),
-    WITHDRAWAL("출금");
+    WITHDRAWAL("출금"),
+    TRANSFER("계좌이체");
 
     private final String koreanName;
 

--- a/ordering/src/main/java/com/beyond/MKX/domain/execution/entity/TransactionType.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/execution/entity/TransactionType.java
@@ -4,13 +4,23 @@ package com.beyond.MKX.domain.execution.entity;
  * 거래 유형을 나타내는 enum
  */
 public enum TransactionType {
-    BUY,              // 매수
-    SELL,             // 매도
-    ORDER_REFUND,     // 주문 환불
-    DELISTING_REFUND, // 상장폐지 환불
-    IPO_PARTICIPATE,  // 공모 참가
-    IPO_REFUND,       // 공모 환불
-    IPO_ADDITIONAL,   // 공모 추가 납입
-    DEPOSIT,          // 입금
-    WITHDRAWAL        // 출금
+    BUY("매수"),
+    SELL("매도"),
+    ORDER_REFUND("주문 환불"),
+    DELISTING_REFUND("상장폐지 환불"),
+    IPO_PARTICIPATE("공모 참가"),
+    IPO_REFUND("공모 환불"),
+    IPO_ADDITIONAL("공모 추가 납입"),
+    DEPOSIT("입금"),
+    WITHDRAWAL("출금");
+
+    private final String koreanName;
+
+    TransactionType(String koreanName) {
+        this.koreanName = koreanName;
+    }
+
+    public String getKoreanName() {
+        return koreanName;
+    }
 }

--- a/ordering/src/main/java/com/beyond/MKX/domain/execution/repository/LedgerRepository.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/execution/repository/LedgerRepository.java
@@ -1,9 +1,25 @@
 package com.beyond.MKX.domain.execution.repository;
 
 import com.beyond.MKX.domain.execution.entity.Ledger;
+import com.beyond.MKX.domain.execution.entity.TransactionType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface LedgerRepository extends JpaRepository<Ledger, UUID> {
+    
+    /**
+     * 특정 계좌의 거래내역을 조회합니다.
+     * creditAccountId 또는 debitAccountId가 memberAccountId와 일치하는 레코드를 조회합니다.
+     */
+    Page<Ledger> findByCreditAccountIdOrDebitAccountIdOrderByCreatedAtDesc(
+        UUID creditAccountId, UUID debitAccountId, Pageable pageable);
+    
+    /**
+     * 특정 계좌의 거래내역을 거래 유형으로 필터링하여 조회합니다.
+     */
+    Page<Ledger> findByCreditAccountIdOrDebitAccountIdAndTransactionTypeOrderByCreatedAtDesc(
+        UUID creditAccountId, UUID debitAccountId, TransactionType transactionType, Pageable pageable);
 }

--- a/ordering/src/main/java/com/beyond/MKX/domain/execution/service/AskExecutionService.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/execution/service/AskExecutionService.java
@@ -6,6 +6,7 @@ import com.beyond.MKX.domain.assets.entity.StockHolding;
 import com.beyond.MKX.domain.assets.repository.StockHoldingRepository;
 import com.beyond.MKX.domain.execution.entity.FillLog;
 import com.beyond.MKX.domain.execution.entity.Ledger;
+import com.beyond.MKX.domain.execution.entity.TransactionType;
 import com.beyond.MKX.domain.execution.repository.FillLogRepository;
 import com.beyond.MKX.domain.execution.repository.LedgerRepository;
 import com.beyond.MKX.domain.order.dto.CommissionAndTaxData;
@@ -126,6 +127,7 @@ public class AskExecutionService {
                 .amountChange(executionEvent.getPrice())
                 .commission(commissionAndTaxData.getCommission())
                 .tax(commissionAndTaxData.getTax())
+                .transactionType(TransactionType.SELL)
                 .build();
         ledgerRepository.save(ledger);
         // TODO: 카프카 발행 및 원장 서비스 모듈 분리

--- a/ordering/src/main/java/com/beyond/MKX/domain/execution/service/BidExecutionService.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/execution/service/BidExecutionService.java
@@ -6,6 +6,7 @@ import com.beyond.MKX.domain.assets.entity.StockHolding;
 import com.beyond.MKX.domain.assets.repository.StockHoldingRepository;
 import com.beyond.MKX.domain.execution.entity.FillLog;
 import com.beyond.MKX.domain.execution.entity.Ledger;
+import com.beyond.MKX.domain.execution.entity.TransactionType;
 import com.beyond.MKX.domain.execution.repository.FillLogRepository;
 import com.beyond.MKX.domain.execution.repository.LedgerRepository;
 import com.beyond.MKX.domain.order.entity.OrderKind;
@@ -154,6 +155,7 @@ public class BidExecutionService {
                 .qtyChange(executionEvent.getQuantity())
                 .amountChange(executionEvent.getPrice())
                 .commission(commission)
+                .transactionType(TransactionType.BUY)
                 .build();
         ledgerRepository.save(ledger);
         // TODO: 카프카 발행 및 원장 서비스 모듈 분리

--- a/ordering/src/main/java/com/beyond/MKX/domain/execution/service/LedgerService.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/execution/service/LedgerService.java
@@ -1,0 +1,66 @@
+package com.beyond.MKX.domain.execution.service;
+
+import com.beyond.MKX.domain.assets.dto.StockInfoResDTO;
+import com.beyond.MKX.domain.execution.dto.LedgerResponseDTO;
+import com.beyond.MKX.domain.execution.entity.Ledger;
+import com.beyond.MKX.domain.execution.entity.TransactionType;
+import com.beyond.MKX.domain.execution.repository.LedgerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class LedgerService {
+    private final LedgerRepository ledgerRepository;
+    private final LedgerStockFeign stockFeign;
+
+    /**
+     * 특정 계좌의 거래내역을 조회합니다.
+     * 
+     * @param memberAccountId 계좌 ID
+     * @param page 페이지 번호 (0부터 시작)
+     * @param size 페이지 크기
+     * @param type 거래 유형 필터 (null이면 전체)
+     * @return 거래내역 페이지
+     */
+    public Page<LedgerResponseDTO> getMyLedgers(UUID memberAccountId, int page, int size, String type) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Ledger> ledgers;
+
+        // 거래 유형 필터링
+        if (type != null && !type.isEmpty() && !type.equals("ALL")) {
+            try {
+                TransactionType transactionType = TransactionType.valueOf(type.toUpperCase());
+                ledgers = ledgerRepository.findByCreditAccountIdOrDebitAccountIdAndTransactionTypeOrderByCreatedAtDesc(
+                    memberAccountId, memberAccountId, transactionType, pageable);
+            } catch (IllegalArgumentException e) {
+                // 잘못된 타입인 경우 전체 조회
+                ledgers = ledgerRepository.findByCreditAccountIdOrDebitAccountIdOrderByCreatedAtDesc(
+                    memberAccountId, memberAccountId, pageable);
+            }
+        } else {
+            // 전체 조회
+            ledgers = ledgerRepository.findByCreditAccountIdOrDebitAccountIdOrderByCreatedAtDesc(
+                memberAccountId, memberAccountId, pageable);
+        }
+
+        // Ledger를 LedgerResponseDTO로 변환 (종목명 조회 포함)
+        return ledgers.map(ledger -> {
+            try {
+                // Feign으로 종목명 조회
+                StockInfoResDTO stockInfo = stockFeign.getStockByTicker(ledger.getTicker());
+                String stockName = stockInfo != null ? stockInfo.getNameKo() : "종목명없음";
+                return LedgerResponseDTO.from(ledger, stockName);
+            } catch (Exception e) {
+                // Feign 호출 실패 시 종목명 없이 반환
+                return LedgerResponseDTO.from(ledger, "종목명없음");
+            }
+        });
+    }
+}
+

--- a/ordering/src/main/java/com/beyond/MKX/domain/execution/service/LedgerStockFeign.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/execution/service/LedgerStockFeign.java
@@ -1,0 +1,13 @@
+package com.beyond.MKX.domain.execution.service;
+
+import com.beyond.MKX.domain.assets.dto.StockInfoResDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "mkx-platform-service", contextId = "ledgerStockFeign")
+public interface LedgerStockFeign {
+    @GetMapping("/api/internal/stocks/{ticker}")
+    StockInfoResDTO getStockByTicker(@PathVariable String ticker);
+}
+

--- a/ordering/src/main/java/com/beyond/MKX/domain/execution/service/TransactionEventConsumer.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/execution/service/TransactionEventConsumer.java
@@ -1,0 +1,159 @@
+package com.beyond.MKX.domain.execution.service;
+
+import com.beyond.MKX.common.kafka.event.TransactionEvent;
+import com.beyond.MKX.domain.execution.entity.Ledger;
+import com.beyond.MKX.domain.execution.entity.TransactionType;
+import com.beyond.MKX.domain.execution.repository.LedgerRepository;
+import com.beyond.MKX.domain.assets.repository.MemberAccountRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * 입출금 거래 이벤트 Consumer
+ * 
+ * - Kafka "transaction-events" 토픽에서 이벤트를 수신
+ * - MEMBER, CORPORATION 계좌의 입금/출금을 Ledger에 기록
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class TransactionEventConsumer {
+    
+    private final LedgerRepository ledgerRepository;
+    private final MemberAccountRepository memberAccountRepository;
+
+    @KafkaListener(
+            topics = "transaction-events",
+            groupId = "${spring.kafka.consumer.transaction-group-id}",
+            containerFactory = "kafkaTransactionListenerFactory"
+    )
+    public void consumeTransactionEvent(
+            @Payload TransactionEvent event,
+            @Header(KafkaHeaders.RECEIVED_PARTITION) String partition,
+            @Header(KafkaHeaders.OFFSET) Long offset,
+            Acknowledgment ack
+    ) {
+        try {
+            log.info("=== Transaction Event 수신: partition={}, offset={}", partition, offset);
+            log.info("TransactionEvent: {}", event);
+
+            // TransactionType 매핑
+            TransactionType transactionType;
+            try {
+                transactionType = TransactionType.valueOf(event.getTransactionType());
+            } catch (IllegalArgumentException e) {
+                log.error("유효하지 않은 TransactionType: {}", event.getTransactionType());
+                ack.acknowledge();
+                return;
+            }
+            
+            // MEMBER 계좌 처리
+            if ("MEMBER".equals(event.getAccountType())) {
+                var accountOpt = memberAccountRepository.findByNumber(event.getAccountNumber());
+                if (accountOpt.isEmpty()) {
+                    log.warn("계좌를 찾을 수 없음: accountNumber={}", event.getAccountNumber());
+                    ack.acknowledge();
+                    return;
+                }
+                
+                var account = accountOpt.get();
+                // accountId를 event에서 받거나 DB 조회로 사용
+                UUID accountId = event.getAccountId() != null && !event.getAccountId().isEmpty()
+                    ? UUID.fromString(event.getAccountId())
+                    : account.getId();
+                UUID brokerageId = account.getBrokerageId();
+
+                // 입금(DEPOSIT): null(시스템) → account (시스템에서 회원 계좌로 입금)
+                // 출금(WITHDRAWAL): account → null(시스템) (회원 계좌에서 시스템으로 출금)
+                UUID creditAccountId;
+                UUID debitAccountId;
+                
+                if (transactionType == TransactionType.DEPOSIT) {
+                    creditAccountId = accountId;    // 입금 받는 쪽: 회원 계좌
+                    debitAccountId = null;           // 입금 보내는 쪽: 시스템(null)
+                } else {
+                    creditAccountId = null;          // 출금 받는 쪽: 시스템(null)
+                    debitAccountId = accountId;      // 출금 보내는 쪽: 회원 계좌
+                }
+
+                // Ledger 기록
+                Ledger ledger = Ledger.builder()
+                        .orderLogId(null)  // 입출금은 주문과 무관
+                        .creditAccountId(creditAccountId)
+                        .debitAccountId(debitAccountId)
+                        .ticker("")  // 입출금은 ticker 없음 (빈 문자열)
+                        .debit(event.getAmount())
+                        .credit(event.getAmount())
+                        .qtyChange(0L)  // 입출금은 거래량 없음
+                        .amountChange(event.getAmount())  // 입출금 금액 = amountChange
+                        .commission(0L)
+                        .tax(0L)
+                        .transactionType(transactionType)
+                        .build();
+                
+                ledgerRepository.save(ledger);
+                log.info("MEMBER Ledger 기록 완료: eventId={}, type={}, amount={}", 
+                        event.getEventId(), transactionType, event.getAmount());
+            } 
+            // CORPORATION 계좌 처리
+            else if ("CORPORATION".equals(event.getAccountType())) {
+                // CORPORATION은 mkx-platform에서 accountId를 전달받음
+                if (event.getAccountId() == null || event.getAccountId().isEmpty()) {
+                    log.warn("CORPORATION 계좌 accountId가 없음: accountNumber={}, 이벤트 건너뜀", event.getAccountNumber());
+                    ack.acknowledge();
+                    return;
+                }
+                
+                UUID corporationAccountId = UUID.fromString(event.getAccountId());
+                
+                // 입금(DEPOSIT): 거래소 → corporation (debitAccountId는 null)
+                // 출금(WITHDRAWAL): corporation → 거래소 (creditAccountId는 null)
+                UUID creditAccountId;
+                UUID debitAccountId;
+                
+                if (transactionType == TransactionType.DEPOSIT) {
+                    creditAccountId = corporationAccountId;  // 입금 받는 쪽: 기업 계좌
+                    debitAccountId = null;                   // 입금 보내는 쪽: null (거래소 계좌 미사용)
+                } else {
+                    creditAccountId = null;                  // 출금 받는 쪽: null (거래소 계좌 미사용)
+                    debitAccountId = corporationAccountId;   // 출금 보내는 쪽: 기업 계좌
+                }
+                
+                // Ledger 기록
+                Ledger ledger = Ledger.builder()
+                        .orderLogId(null)
+                        .creditAccountId(creditAccountId)
+                        .debitAccountId(debitAccountId)
+                        .ticker("")  // 입출금은 ticker 없음 (빈 문자열)
+                        .debit(event.getAmount())
+                        .credit(event.getAmount())
+                        .qtyChange(0L)  // 입출금은 거래량 없음
+                        .amountChange(event.getAmount())  // 입출금 금액 = amountChange
+                        .commission(0L)
+                        .tax(0L)
+                        .transactionType(transactionType)
+                        .build();
+                
+                ledgerRepository.save(ledger);
+                log.info("CORPORATION Ledger 기록 완료: eventId={}, type={}, amount={}, accountId={}", 
+                        event.getEventId(), transactionType, event.getAmount(), corporationAccountId);
+            }
+
+            ack.acknowledge();
+            log.info("=== Transaction Event 처리 완료 ===");
+            
+        } catch (Exception e) {
+            log.error("Transaction Event 처리 실패: {}", e.getMessage(), e);
+            throw e;
+        }
+    }
+}
+

--- a/ordering/src/main/java/com/beyond/MKX/domain/execution/service/TransactionEventConsumer.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/execution/service/TransactionEventConsumer.java
@@ -73,15 +73,42 @@ public class TransactionEventConsumer {
 
                 // 입금(DEPOSIT): null(시스템) → account (시스템에서 회원 계좌로 입금)
                 // 출금(WITHDRAWAL): account → null(시스템) (회원 계좌에서 시스템으로 출금)
+                // 이체(TRANSFER): 계좌간 이체 (상대방 정보 포함)
                 UUID creditAccountId;
                 UUID debitAccountId;
+                Long debitAmount;
+                Long creditAmount;
                 
                 if (transactionType == TransactionType.DEPOSIT) {
                     creditAccountId = accountId;    // 입금 받는 쪽: 회원 계좌
                     debitAccountId = null;           // 입금 보내는 쪽: 시스템(null)
-                } else {
+                    debitAmount = 0L;
+                    creditAmount = event.getAmount();
+                } else if (transactionType == TransactionType.WITHDRAWAL) {
                     creditAccountId = null;          // 출금 받는 쪽: 시스템(null)
                     debitAccountId = accountId;      // 출금 보내는 쪽: 회원 계좌
+                    debitAmount = event.getAmount();
+                    creditAmount = 0L;
+                } else if (transactionType == TransactionType.TRANSFER) {
+                    // 이체는 method로 입금/출금 구분 (publishTransferDepositEvent는 입금, publishTransferWithdrawalEvent는 출금)
+                    if ("TRANSFER_DEPOSIT".equals(event.getMethod()) || event.getMethod() == null) {
+                        // 이체 입금: 다른 계좌 → 내 계좌
+                        creditAccountId = accountId;
+                        debitAccountId = null;
+                        debitAmount = 0L;
+                        creditAmount = event.getAmount();
+                    } else {
+                        // 이체 출금: 내 계좌 → 다른 계좌
+                        creditAccountId = null;
+                        debitAccountId = accountId;
+                        debitAmount = event.getAmount();
+                        creditAmount = 0L;
+                    }
+                } else {
+                    creditAccountId = null;
+                    debitAccountId = accountId;
+                    debitAmount = event.getAmount();
+                    creditAmount = 0L;
                 }
 
                 // Ledger 기록
@@ -90,18 +117,21 @@ public class TransactionEventConsumer {
                         .creditAccountId(creditAccountId)
                         .debitAccountId(debitAccountId)
                         .ticker("")  // 입출금은 ticker 없음 (빈 문자열)
-                        .debit(event.getAmount())
-                        .credit(event.getAmount())
+                        .debit(debitAmount)
+                        .credit(creditAmount)
                         .qtyChange(0L)  // 입출금은 거래량 없음
                         .amountChange(event.getAmount())  // 입출금 금액 = amountChange
                         .commission(0L)
                         .tax(0L)
                         .transactionType(transactionType)
+                        .counterpartyAccountNumber(event.getCounterpartyAccountNumber())
+                        .counterpartyName(event.getCounterpartyName())
                         .build();
                 
                 ledgerRepository.save(ledger);
-                log.info("MEMBER Ledger 기록 완료: eventId={}, type={}, amount={}", 
-                        event.getEventId(), transactionType, event.getAmount());
+                log.info("MEMBER Ledger 기록 완료: eventId={}, type={}, amount={}, counterparty={}", 
+                        event.getEventId(), transactionType, event.getAmount(), 
+                        event.getCounterpartyName() != null ? event.getCounterpartyName() : "N/A");
             } 
             // CORPORATION 계좌 처리
             else if ("CORPORATION".equals(event.getAccountType())) {


### PR DESCRIPTION
## 📋 작업 개요
Ledger 기반 거래내역 시스템 고도화 및 Kafka 이벤트 발행 연동

<br/>

## 🔧 작업 상세
- **Ledger 엔티티 개선**
  - `TransactionType` enum 및 한글명 필드 추가 (`BUY`, `SELL`, `REFUND`, `DEPOSIT`, `WITHDRAWAL` 등)
  - `Ledger.transactionType` 컬럼 추가 (nullable, VARCHAR)
  - `ticker` nullable 허용으로 비주식 거래(입출금) 대응  
- **거래내역 조회 기능**
  - `/api/ledgers/my-account/{memberAccountId}` 엔드포인트 추가  
  - 거래유형별 필터링 및 페이지네이션 지원  
  - `LedgerResponseDTO` 생성 및 한글명·수수료·세금·순금액 포함  
  - FeignClient(`LedgerStockFeign`) 기반 종목명 조회 연동  
- **Kafka 기반 이벤트 발행 및 수신**
  - `TransactionEvent` DTO 추가 (입출금·이체 이벤트 모델)
  - Producer/Consumer 설정 (`KafkaProducerConfig`, `KafkaConsumerConfig`) 구성  
  - `TransactionEventPublisher` 서비스 생성  
    - 기업/회원 계좌 입출금 시 `transaction-events` 토픽 발행  
    - 계좌번호, 금액, 거래유형, 방법(`BANK_TRANSFER`) 포함  
  - Consumer 구현으로 Ledger 자동 기록 및 수동 커밋 처리  
- **계좌이체 기능 구현**
  - `MemberAccountService`에 계좌 간 이체 로직 추가 (출금/입금 트랜잭션 처리)
  - `/api/accounts/member/{fromAccountNumber}/transfer` API 구현  
  - Ledger에 상대방 계좌 정보 기록 및 Kafka 이벤트 발행
  - 수취인 이름 조회 API 연동 및 상세 로깅 추가

<br/>

## 📌 이슈 번호
close #103 

<br/>

## 🧪 테스트 결과
- Postman을 통한 거래내역 필터링 및 페이지네이션 검증  
- Kafka 토픽(`transaction-events`) 발행/수신 로그 정상 확인  
- 계좌이체 시 Ledger 자동 기록 및 입출금 구분(`debit`/`credit`) 정상 반영  
- 예외 상황(존재하지 않는 계좌, 잔액 부족 등)에 대한 트랜잭션 롤백 테스트 완료  

<br/>

## ⚠️ 참고사항
- 로컬 환경은 `ddl-auto=update`로 자동 스키마 반영  
- 프로덕션 환경은 수동 SQL 마이그레이션 스크립트 필요  
- Kafka Broker 및 Topic 설정은 `docker-compose.kafka.yml` 기준  
- 향후 거래내역 조회 시 종목명 캐싱 로직 보완 예정  

<br/>

## 👥 리뷰어 지정
@jinnn12 @ggj0228 

<br/>

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.  
- [x] 코드에 대한 테스트를 진행 하였으며, 결과에 대한 자료를 첨부하였습니다.  
- [x] 최소 2명의 리뷰어를 지정했습니다.  
