### PR TITLE
[Fix] 수요예측 기반 확정 공모가 로직 현실 기반 수정 (#107)

### DIFF
--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/ipo/bookbuilding/service/IpoBookBuildingService.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/ipo/bookbuilding/service/IpoBookBuildingService.java
@@ -110,14 +110,15 @@ public class IpoBookBuildingService {
 
     @Transactional
     public IpoOffering fixOfferPriceByBookBuilding(UUID offeringId) {
+
+        /** 0️⃣ 사전 검증 — 상태 및 데이터 확인 */
         IpoOffering offering = offeringRepository.findByIdForUpdate(offeringId)
                 .orElseThrow(() -> new IllegalArgumentException("공모 없음."));
         if (offering.getIpoOfferingStatus() == IpoOfferingStatus.PRICE_FIXED) {
             throw new IllegalStateException("이미 확정된 공모입니다.");
         }
-
         if (offering.getIpoOfferingStatus() != IpoOfferingStatus.BOOK_BUILDING) {
-            throw new IllegalArgumentException("BOOK_BUILDING 상태에서만 수요예측 결과 ' 확정 ' 이 가능합니다.");
+            throw new IllegalArgumentException("BOOK_BUILDING 상태에서만 확정 가능합니다.");
         }
 
         List<IpoBookBuilding> bookBuildings = bookBuildingRepository.findAllByIpoOffering_Id(offeringId);
@@ -130,66 +131,86 @@ public class IpoBookBuildingService {
         long min = offering.getPriceBandMin();
         long max = offering.getPriceBandMax();
 
-        /** 1) 가격대별 수요량 집계 */
+        /** 1️⃣ 가격대별 수요량 초기화 */
         Map<Long, Long> demandMap = new TreeMap<>();
         for (long price = min; price <= max; price += 100) {
             demandMap.put(price, 0L);
         }
 
-        // 🔹 가격 무관 응찰 → 밴드 하단(min)에 1회만 반영 (한국거래소·금융투자협회 기관청약시스템 로직과 동일)
-        //    가격 무관 참여의 경우 ( acceptAllPrices = true || 희망가 미기재 (bidPrice == null) )
-        for (IpoBookBuilding bookBuilding : bookBuildings) {
-            long bid = (bookBuilding.getBidPrice() == null)
-                    ? min
-                    : Math.max(min, Math.min(max, bookBuilding.getBidPrice()));
-            demandMap.put(bid, demandMap.getOrDefault(bid, 0L) + bookBuilding.getBidQuantity());
+        /** 2️⃣ 참여자별 응찰 가격·수량 반영 */
+        for (IpoBookBuilding bb : bookBuildings) {
+            long bid = (bb.getBidPrice() == null)
+                    ? min   // 가격무관 응찰은 밴드 하단으로 처리
+                    : Math.max(min, Math.min(max, bb.getBidPrice())); // 밴드 내로 보정
+            demandMap.put(bid, demandMap.getOrDefault(bid, 0L) + bb.getBidQuantity());
         }
 
-        /** 2) 누적 수요 기준, 경쟁률 계산 */
+        /** 3️⃣ 전체 수요 및 경쟁률 계산 */
         long cumulative = bookBuildings.stream().mapToLong(IpoBookBuilding::getBidQuantity).sum();
         double ratio = (double) cumulative / offerQuantity;
 
-        /** 3-1) 전체 수요 기반 가중 평균가격 계산 (신규 추가 부분) */
+        /** 4️⃣ 가중평균 희망가격 계산 (시장 기대치 반영) */
         long totalDemand = 0L;
         long weightedSum = 0L;
         for (IpoBookBuilding b : bookBuildings) {
-            Long bid = (b.getBidPrice() == null)
-                    ? min // 가격 무관 참여는 하한가로 처리
-                    : Math.max(min, Math.min(max, b.getBidPrice())); // 밴드 범위 보정
+            long bid = (b.getBidPrice() == null)
+                    ? min
+                    : Math.max(min, Math.min(max, b.getBidPrice()));
             weightedSum += bid * b.getBidQuantity();
             totalDemand += b.getBidQuantity();
         }
         long weightedAvgPrice = (totalDemand > 0) ? (weightedSum / totalDemand) : min;
 
-        /** 3-2) 확정공모가 계산 */
+        /** 5️⃣ 확정공모가 산정 로직 */
         long fixedPrice;
-        if (ratio < 1.0) {
-            fixedPrice = min; // 미달 — 하단 확정
-        } else if (ratio >= 10.0) {
-            // 🔥 초과 청약 (10배 이상)
-            // 상단 초과 — 상단 + (상단-하단)의 10% 추가 반영
-            long overPrice = max + Math.round((max - min) * 0.1);
-            fixedPrice = overPrice;
-        } else if (ratio >= 2.0) {
-            // 2배 이상 → 상단 확정
-            fixedPrice = max;
-        } else {
-            // 1.0 ≤ 경쟁률 < 2.0 구간
-            double normalized = (ratio - 1.0) / (2.0 - 1.0); // 0~1
-            double avgWeight = 1.0 - 0.8 * normalized; // 평균가 가중치 점진 감소
-            double maxWeight = 0.0 + 0.8 * normalized; // 상단가 가중치 점진 증가
+        final double X1 = 1.0;  // 경쟁률 하한 (미달)
+        final double X2 = 2.0;  // 경쟁률 상한 (과열)
+        final double X3 = 10.0; // 초과수요 기준
+        final double alpha = 0.5; // 미달구간 희망가 반영비율
+
+        if (ratio < X1) {
+            // 미달구간 — 밴드 하단가 + 희망가 평균 50% 반영
+            fixedPrice = Math.round(min + alpha * (weightedAvgPrice - min));
+        } else if (ratio < X2) {
+            // 적정수요구간 — 가중평균가와 상단가 혼합
+            double normalized = (ratio - X1) / (X2 - X1); // 1.0→0, 2.0→1
+            double avgWeight = 1.0 - 0.8 * normalized;
+            double maxWeight = 0.8 * normalized;
             double finalPrice = weightedAvgPrice * avgWeight + max * maxWeight;
             fixedPrice = Math.round(finalPrice);
+        } else if (ratio < X3) {
+            // 과수요구간 — 상단가와 상위10% 희망가 평균 중 큰 값
+            long topPrice = calculateTopPercentilePrice(bookBuildings, 0.10);
+            fixedPrice = Math.max(max, topPrice);
+        } else {
+            // 초과수요구간 — 밴드 초과 10% 허용
+            long overPrice = max + Math.round((max - min) * 0.1);
+            fixedPrice = overPrice;
         }
 
-        if (ratio < 10.0) {
+        /** 6️⃣ 밴드 내 클램프 + 10원 단위 반올림 */
+        if (ratio < X3) {
             fixedPrice = Math.max(min, Math.min(max, fixedPrice));
         }
+        fixedPrice = Math.round(fixedPrice / 10.0) * 10; // 💰 10원 단위로 조정
 
-        /** 4) 경쟁률 기록 + 확정 공모가 반영 */
+        /** 7️⃣ 결과 저장 */
         offering.setCompetitionRatio(BigDecimal.valueOf(ratio).setScale(2, RoundingMode.HALF_UP));
         offering.fixOfferPrice(fixedPrice, min, max, face);
+
         return offeringRepository.save(offering);
+    }
+    /** 상위 N% 가격 평균 계산 헬퍼 (optional) */
+    private long calculateTopPercentilePrice(List<IpoBookBuilding> list, double percentile) {
+        if (list.isEmpty()) return 0L;
+        int cutoff = (int) Math.ceil(list.size() * (1 - percentile));
+        List<Long> sorted = list.stream()
+                .map(b -> b.getBidPrice() == null ? 0L : b.getBidPrice())
+                .sorted()
+                .toList();
+        return Math.round(sorted.subList(cutoff, sorted.size()).stream()
+                .mapToLong(Long::longValue)
+                .average().orElse(0.0));
     }
 
     /**

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/ipo/subscription/controller/IpoSubscriptionController.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/ipo/subscription/controller/IpoSubscriptionController.java
@@ -1,13 +1,17 @@
 package com.beyond.MKX.domain.ipo.subscription.controller;
 
 import com.beyond.MKX.common.apiResponse.ApiResponse;
+import com.beyond.MKX.common.auth.security.CustomAdminPrincipal;
+import com.beyond.MKX.common.auth.security.CustomMemberPrincipal;
 import com.beyond.MKX.domain.ipo.subscription.dto.IpoSubscriptionReqDTO;
 import com.beyond.MKX.domain.ipo.subscription.dto.IpoSubscriptionResDTO;
 import com.beyond.MKX.domain.ipo.subscription.dto.DepositReqDTO;
+import com.beyond.MKX.domain.ipo.subscription.entity.InvestorType;
 import com.beyond.MKX.domain.ipo.subscription.service.IpoSubscriptionService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.*;
@@ -48,6 +52,22 @@ public class IpoSubscriptionController {
     public ResponseEntity<?> getAll(@PathVariable UUID offeringId) {
         List<IpoSubscriptionResDTO> res = subscriptionService.findAll(offeringId);
         return ApiResponse.ok(res, "해당 공모의 청약 리스트입니다.");
+    }
+
+    /** 개인 투자자 본인 청약 내역 조회 */
+    @GetMapping("/member")
+    public ResponseEntity<?> getMySubscriptionsForMember(@AuthenticationPrincipal CustomMemberPrincipal principal) {
+        UUID memberId = principal.id();
+        List<IpoSubscriptionResDTO> res = subscriptionService.findAllBySubscriber(memberId, InvestorType.INDIVIDUAL);
+        return ApiResponse.ok(res, "개인 투자자의 청약 내역입니다.");
+    }
+
+    /** 기업 투자자 본인 청약 내역 조회 */
+    @GetMapping("/corporation")
+    public ResponseEntity<?> getMySubscriptionsForCorporation(@AuthenticationPrincipal CustomAdminPrincipal principal) {
+        UUID corporationId = principal.id();
+        List<IpoSubscriptionResDTO> res = subscriptionService.findAllBySubscriber(corporationId, InvestorType.CORPORATION);
+        return ApiResponse.ok(res, "기업 투자자의 청약 내역입니다.");
     }
 
     /** 청약 납입(APPLIED -> PAID) / 향후 시간이 된다면 추가공모로직으로 쓸 예정 / 아마 못 쓸 듯, 그래도 아까워서  */

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/ipo/subscription/controller/IpoSubscriptionController.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/ipo/subscription/controller/IpoSubscriptionController.java
@@ -3,6 +3,9 @@ package com.beyond.MKX.domain.ipo.subscription.controller;
 import com.beyond.MKX.common.apiResponse.ApiResponse;
 import com.beyond.MKX.common.auth.security.CustomAdminPrincipal;
 import com.beyond.MKX.common.auth.security.CustomMemberPrincipal;
+import com.beyond.MKX.domain.admin.entity.Admin;
+import com.beyond.MKX.domain.admin.repository.AdminRepository;
+import com.beyond.MKX.domain.corporation.entity.Corporation;
 import com.beyond.MKX.domain.ipo.subscription.dto.IpoSubscriptionReqDTO;
 import com.beyond.MKX.domain.ipo.subscription.dto.IpoSubscriptionResDTO;
 import com.beyond.MKX.domain.ipo.subscription.dto.DepositReqDTO;
@@ -21,6 +24,7 @@ import java.util.*;
 @RequiredArgsConstructor
 public class IpoSubscriptionController {
     private final IpoSubscriptionService subscriptionService;
+    private final AdminRepository adminRepository;
 
     /* 청약 신청(APPLY) & 증거금 납입 (PAID) 원큐 */
     @PostMapping
@@ -58,15 +62,22 @@ public class IpoSubscriptionController {
     @GetMapping("/member")
     public ResponseEntity<?> getMySubscriptionsForMember(@AuthenticationPrincipal CustomMemberPrincipal principal) {
         UUID memberId = principal.id();
-        List<IpoSubscriptionResDTO> res = subscriptionService.findAllBySubscriber(memberId, InvestorType.INDIVIDUAL);
+        List<IpoSubscriptionResDTO> res = subscriptionService.findAllByMember(memberId, InvestorType.INDIVIDUAL);
         return ApiResponse.ok(res, "개인 투자자의 청약 내역입니다.");
     }
 
     /** 기업 투자자 본인 청약 내역 조회 */
     @GetMapping("/corporation")
     public ResponseEntity<?> getMySubscriptionsForCorporation(@AuthenticationPrincipal CustomAdminPrincipal principal) {
-        UUID corporationId = principal.id();
-        List<IpoSubscriptionResDTO> res = subscriptionService.findAllBySubscriber(corporationId, InvestorType.CORPORATION);
+        Admin admin = adminRepository.findById(principal.id()).orElseThrow(() -> new IllegalArgumentException("관리자 없음"));
+        Corporation corporation = admin.getCorporation();
+        UUID corporationId = corporation.getId();
+
+        if (principal == null) {
+            throw new IllegalArgumentException("인증되지 않은 요청입니다.");
+        }
+
+        List<IpoSubscriptionResDTO> res = subscriptionService.findAllByCorporation(corporationId, InvestorType.CORPORATION);
         return ApiResponse.ok(res, "기업 투자자의 청약 내역입니다.");
     }
 

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/ipo/subscription/repository/IpoSubscriptionRepository.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/ipo/subscription/repository/IpoSubscriptionRepository.java
@@ -1,5 +1,6 @@
 package com.beyond.MKX.domain.ipo.subscription.repository;
 
+import com.beyond.MKX.domain.ipo.subscription.entity.InvestorType;
 import com.beyond.MKX.domain.ipo.subscription.entity.IpoSubscription;
 import com.beyond.MKX.domain.ipo.subscription.entity.SubscriptionStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -42,4 +43,6 @@ public interface IpoSubscriptionRepository extends JpaRepository<IpoSubscription
     List<IpoSubscription> findAllByOfferingIdAndStatus(
             @Param("offeringId") UUID offeringId,
             @Param("status") SubscriptionStatus status);
+
+    List<IpoSubscription> findAllBySubscriberIdAndInvestorType(UUID subscriberId, InvestorType investorType);
 }

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/ipo/subscription/service/IpoSubscriptionService.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/ipo/subscription/service/IpoSubscriptionService.java
@@ -75,7 +75,7 @@ public class IpoSubscriptionService {
 
 //        3) 중복 청약 방지 (한 계좌당 한 회차의 공모 청약 가능)
         boolean subscriptionExist = false;
-        
+
         if (subReqDto.investorType() == InvestorType.CORPORATION) {
             // 기업 투자자: accountId로 중복 체크
             subscriptionExist = subscriptionRepository.existsByIpoOffering_IdAndAccountId(
@@ -87,7 +87,7 @@ public class IpoSubscriptionService {
                     subReqDto.ipoOfferingId(), subReqDto.accountNumber()
             );
         }
-        
+
         if (subscriptionExist) {
             throw new IllegalArgumentException("동일 계좌로 이미 청약하셨습니다.");
         }
@@ -163,6 +163,7 @@ public class IpoSubscriptionService {
         return dto; // ✅ 계산된 경쟁RatioX 포함하여 반환
 
     }
+
     // 확정가가 있으면 그 값을, 없으면 밴드 상단을 사용(보수적 증거금).
     private long resolveEffectivePrice(IpoOffering ipoOffering) {
         Long price = ipoOffering.getOfferPrice();
@@ -244,7 +245,7 @@ public class IpoSubscriptionService {
         return dto;
     }
 
-//    경쟁률 계산기
+    //    경쟁률 계산기
     private BigDecimal computeCompetitionRatioX(IpoOffering o) {
         long paidQty = subscriptionRepository
                 .sumAppliedQuantityByOffering(o.getId(), SubscriptionStatus.PAID);
@@ -268,7 +269,9 @@ public class IpoSubscriptionService {
                 .collect(Collectors.toList());
     }
 
-    /** 발행사 관점: 기관만 실명, 개인은 익명 처리 */
+    /**
+     * 발행사 관점: 기관만 실명, 개인은 익명 처리
+     */
     private String resolveSubscriberNameForCorporationView(IpoSubscription sub) {
         if (sub.getInvestorType() == InvestorType.CORPORATION) {
             return corporationRepository.findById(sub.getSubscriberId())
@@ -279,8 +282,9 @@ public class IpoSubscriptionService {
         return "개인 투자자";
     }
 
+    //    개인 투자자 청약 조회
     @Transactional(readOnly = true)
-    public List<IpoSubscriptionResDTO> findAllBySubscriber(UUID subscriberId, InvestorType type) {
+    public List<IpoSubscriptionResDTO> findAllByMember(UUID subscriberId, InvestorType type) {
         List<IpoSubscription> list = subscriptionRepository.findAllBySubscriberIdAndInvestorType(subscriberId, type);
 
         return list.stream()
@@ -292,6 +296,19 @@ public class IpoSubscriptionService {
                 .collect(Collectors.toList());
     }
 
+    //    기업 투자자 청약 조회
+    @Transactional(readOnly = true)
+    public List<IpoSubscriptionResDTO> findAllByCorporation(UUID subscriberId, InvestorType type) {
+        List<IpoSubscription> list = subscriptionRepository.findAllBySubscriberIdAndInvestorType(subscriberId, type);
+
+        return list.stream()
+                .map(sub -> {
+                    IpoSubscriptionResDTO dto = IpoSubscriptionResDTO.from(sub);
+                    dto.setCompetitionRatioX(computeCompetitionRatioX(sub.getIpoOffering()));
+                    return dto;
+                })
+                .collect(Collectors.toList());
+    }
 
     /** 향후 추가 공모 로직 시간이 된다면 쓸 예정 ... */
 //    @Transactional

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/ipo/subscription/service/IpoSubscriptionService.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/ipo/subscription/service/IpoSubscriptionService.java
@@ -279,6 +279,20 @@ public class IpoSubscriptionService {
         return "개인 투자자";
     }
 
+    @Transactional(readOnly = true)
+    public List<IpoSubscriptionResDTO> findAllBySubscriber(UUID subscriberId, InvestorType type) {
+        List<IpoSubscription> list = subscriptionRepository.findAllBySubscriberIdAndInvestorType(subscriberId, type);
+
+        return list.stream()
+                .map(sub -> {
+                    IpoSubscriptionResDTO dto = IpoSubscriptionResDTO.from(sub);
+                    dto.setCompetitionRatioX(computeCompetitionRatioX(sub.getIpoOffering()));
+                    return dto;
+                })
+                .collect(Collectors.toList());
+    }
+
+
     /** 향후 추가 공모 로직 시간이 된다면 쓸 예정 ... */
 //    @Transactional
 //    public IpoSubscriptionResDTO deposit(UUID subscriptionId, long depositAmount) {


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
수요예측 기반 확정 공모가 로직 현실 기반 수정 및 유저 플로우 개선을 위한 본인 청약 조회 로직 개발
<br/>

## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- 기존에는 경쟁률 미달 / 과열의 경우 밴드 하한가 / 상한가 100% 반영하였으나, 이 경우 수요예측 참여 기업들의 희망 가격이 반영이 되지 않는 현상 발생
- X1, X2, X3 으로 경쟁률을 변수로 바꾸어 거래소 정책에서 원하는 경쟁률에 따라 수요예측에 따른 공모가 확정 유연하게 변경 가능
- 구간별 세분화하여 공모가 확정 하는 로직 가중평균 반영 
- 경쟁률이 X1 (현재는 1.0) 이하일 경우 "미달"로 잡고, 밴드 하단가 + 희망가 평균 50% 반영
- 경쟁률이 X2 (현재는 2.0) 이상일 경우 "과열"로 잡고, 밴드 상단가 + 희망가 평균 10% 반영
- X1 ~ X2 사이의 경우 "적정 수요 구간"으로 판단하여 weightedAvgPrice를 활용해 가중평균가 + 상단가 혼합
- 경쟁률이 X3 (현재는 10.0) 이상일 경우 "초과열"로 잡고, 상단가와 상위 10% 희망가 평균 중 큰 값으로 공모가 확정 (상위 10% 평균 계산 메서드 포함)
- 변경 전에는 확정 공모가가 1의 자리도 표시되었으나, 10의 자리까지 반올림 하도록 설정
- 청약 투자자 본인 청약 조회 로직 추가
- 개인 투자자의 경우 CustomMemberPrincipal 객체를 활용하여 id를 가져올 수 있었으나, Corporation의 경우 Admin 객체 - Corporation 객체 내 id를 활용함
<br/>

## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #107 
<br/>

## 🧪 테스트 결과
<!-- 코드 검증 시 진행한 테스트 결과에 대한 캡쳐 이미지나 영상 혹은 기타 자료를 첨부해주세요. -->
<!-- 어떤 방식으로 테스트를 진행 하였으며, 왜 그 방식을 채택 했는지에 대한 설명도 작성해주세요. -->
<!-- 성능 테스트 방식이 잘못 되었거나 누락 되어있다면 PR은 거절됩니다. -->

<br/>

## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  

<br/>

## 👥 리뷰어 지정
<!-- 반드시 2명 이상 리뷰어를 지정해주세요 -->
<!-- 모든 리뷰어가 PR 리뷰를 마친 뒤 병합을 진행합니다. -->
<!-- 예: @username1 @username2 -->

<br/>

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: Feat: 테이블 등록 기능 구현 -->
- [ ] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.
- [ ] 코드에 대한 테스트를 진행 하였으며, 결과에 대한 자료를 첨부하였습니다.
- [ ] 최소 2명의 리뷰어를 지정했습니다.