### PR TITLE
[Feat, Fix] 상장폐지 로직 고도화 마무리 (#118)

### DIFF
--- a/mkx-platform/Trading Bot.postman_collection.json
+++ b/mkx-platform/Trading Bot.postman_collection.json
@@ -1,0 +1,346 @@
+{
+	"info": {
+		"_postman_id": "cdb18a86-2e49-4f29-b74a-f4eeeec0c69d",
+		"name": "Trading Bot",
+		"description": "상장폐지 도메인 전체 API 테스트 컬렉션 (수정된 버전 - Stock Holdings 삭제 & Kafka 이벤트 발행 포함)",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "43742779",
+		"_collection_link": "https://hyeseongbak.postman.co/workspace/Hyeseong-Bak's-Workspace~143b1d12-ef7c-4668-829e-6bea84a768cf/collection/43742779-cdb18a86-2e49-4f29-b74a-f4eeeec0c69d?action=share&source=collection_link&creator=43742779"
+	},
+	"item": [
+		{
+			"name": "봇 Copy",
+			"item": [
+				{
+					"name": "Health Check",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/health",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"health"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Test Health Check",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/test/api/trading-bot/test/health",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"test",
+								"api",
+								"trading-bot",
+								"test",
+								"health"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create Dynamic Bots - MKX001",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/test/api/trading-bot/test/dynamic/MKX001",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"test",
+								"api",
+								"trading-bot",
+								"test",
+								"dynamic",
+								"MKX001"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create Dynamic Bots - MKX002",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/test/api/trading-bot/test/dynamic/MKX002",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"test",
+								"api",
+								"trading-bot",
+								"test",
+								"dynamic",
+								"MKX002"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create Dynamic Bots - MKX006",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/test/api/trading-bot/test/dynamic/MKX006",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"test",
+								"api",
+								"trading-bot",
+								"test",
+								"dynamic",
+								"MKX006"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Active Bots",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/test/api/trading-bot/test/configs/active",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"test",
+								"api",
+								"trading-bot",
+								"test",
+								"configs",
+								"active"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Deactivate All Bots",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/test/api/trading-bot/configs/all",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"test",
+								"api",
+								"trading-bot",
+								"configs",
+								"all"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create Single Bot",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"ticker\": \"MKX001\",\n  \"status\": \"START\",\n  \"priceLimitHigh\": 55000,\n  \"priceLimitLow\": 45000,\n  \"quantity\": 10,\n  \"side\": \"BUY\",\n  \"orderType\": \"LIMIT\",\n  \"brokerageId\": \"TEST_BROKER\",\n  \"description\": \"테스트 매수 봇\"\n}"
+						},
+						"url": {
+							"raw": "{{base_url}}/test/api/trading-bot/config",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"test",
+								"api",
+								"trading-bot",
+								"config"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update Bot Status",
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"status\": \"END\"\n}"
+						},
+						"url": {
+							"raw": "{{base_url}}/test/api/trading-bot/config/{{bot_id}}/status",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"test",
+								"api",
+								"trading-bot",
+								"config",
+								"{{bot_id}}",
+								"status"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Deactivate Single Bot",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/test/api/trading-bot/config/{{bot_id}}",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"test",
+								"api",
+								"trading-bot",
+								"config",
+								"{{bot_id}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Bots by Status",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/test/api/trading-bot/configs/status/START",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"test",
+								"api",
+								"trading-bot",
+								"configs",
+								"status",
+								"START"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Test Matching Engine",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"brokerageId\": \"TEST_BROKER\",\n  \"orderId\": \"test-order-123\",\n  \"ticker\": \"MKX001\",\n  \"side\": \"BUY\",\n  \"orderType\": \"LIMIT\",\n  \"price\": 50000,\n  \"quantity\": 10,\n  \"createdAt\": \"2025-10-19T17:30:00\"\n}"
+						},
+						"url": {
+							"raw": "{{base_url}}/matching-engine-service/test/order",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"matching-engine-service",
+								"test",
+								"order"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "New Request",
+					"request": {
+						"method": "GET",
+						"header": []
+					},
+					"response": []
+				}
+			]
+		}
+	],
+	"variable": [
+		{
+			"key": "baseUrl",
+			"value": "http://localhost:8080",
+			"type": "string"
+		},
+		{
+			"key": "stockId",
+			"value": "00000000-0000-0000-0000-000000000001",
+			"type": "string",
+			"description": "테스트할 주식 ID"
+		},
+		{
+			"key": "violationId",
+			"value": "00000000-0000-0000-0000-000000000002",
+			"type": "string"
+		},
+		{
+			"key": "criteriaId",
+			"value": "00000000-0000-0000-0000-000000000003",
+			"type": "string"
+		},
+		{
+			"key": "memberAccountId",
+			"value": "00000000-0000-0000-0000-000000000004",
+			"type": "string"
+		},
+		{
+			"key": "corporationId",
+			"value": "00000000-0000-0000-0000-000000000005",
+			"type": "string"
+		},
+		{
+			"key": "adminId",
+			"value": "00000000-0000-0000-0000-000000000006",
+			"type": "string"
+		},
+		{
+			"key": "supportFundId",
+			"value": "00000000-0000-0000-0000-000000000007",
+			"type": "string"
+		}
+	]
+}

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/delisting/controller/DelistingController.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/delisting/controller/DelistingController.java
@@ -142,6 +142,17 @@ public class DelistingController {
         return ApiResponse.ok(report, "상장폐지 위험 분석 리포트 생성 완료");
     }
 
+    /**
+     * 위험 해소 처리 (문제 없음 처리)
+     */
+    @PostMapping("/risk/resolve/{stockId}")
+    public ResponseEntity<?> resolveRisk(@PathVariable UUID stockId,
+                                        @RequestParam UUID adminId,
+                                        @RequestParam(required = false) String reason) {
+        delistingService.resolveRisk(stockId, adminId, reason);
+        return ApiResponse.ok(null, "위험 해소 처리 완료");
+    }
+
     private DelistingViolationResDto mapToResDto(DelistingViolation violation) {
         return DelistingViolationResDto.builder()
                 .id(violation.getId())

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/delisting/repository/ExchangeSupportFundRepository.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/delisting/repository/ExchangeSupportFundRepository.java
@@ -48,26 +48,26 @@ public interface ExchangeSupportFundRepository extends JpaRepository<ExchangeSup
     List<ExchangeSupportFund> findOverdueSupports();
 
     /**
-     * 기업별 총 지원금 합계 조회
+     * 기업별 총 지원금 합계 조회 (상환 완료된 것도 포함)
      */
-    @Query("SELECT SUM(e.supportAmount) FROM ExchangeSupportFund e WHERE e.corporationId = :corporationId AND e.status IN ('ACTIVE', 'PARTIAL_REPAID', 'OVERDUE')")
+    @Query("SELECT SUM(e.supportAmount) FROM ExchangeSupportFund e WHERE e.corporationId = :corporationId AND e.status IN ('ACTIVE', 'PARTIAL_REPAID', 'OVERDUE', 'REPAID')")
     BigDecimal getTotalSupportAmountByCorporation(@Param("corporationId") UUID corporationId);
 
     /**
-     * 기업별 미상환 금액 조회
+     * 기업별 미상환 금액 조회 (상환 완료된 것은 0으로 계산됨)
      */
-    @Query("SELECT SUM(e.supportAmount - e.repaidAmount) FROM ExchangeSupportFund e WHERE e.corporationId = :corporationId AND e.status IN ('ACTIVE', 'PARTIAL_REPAID', 'OVERDUE')")
+    @Query("SELECT SUM(e.supportAmount - e.repaidAmount) FROM ExchangeSupportFund e WHERE e.corporationId = :corporationId AND e.status IN ('ACTIVE', 'PARTIAL_REPAID', 'OVERDUE', 'REPAID')")
     BigDecimal getUnpaidAmountByCorporation(@Param("corporationId") UUID corporationId);
 
     /**
-     * 거래소 총 지원금 합계 조회
+     * 거래소 총 지원금 합계 조회 (상환 완료된 것도 포함)
      */
-    @Query("SELECT SUM(e.supportAmount) FROM ExchangeSupportFund e WHERE e.status IN ('ACTIVE', 'PARTIAL_REPAID', 'OVERDUE')")
+    @Query("SELECT SUM(e.supportAmount) FROM ExchangeSupportFund e WHERE e.status IN ('ACTIVE', 'PARTIAL_REPAID', 'OVERDUE', 'REPAID')")
     BigDecimal getTotalActiveSupportAmount();
 
     /**
-     * 거래소 총 미상환 금액 조회
+     * 거래소 총 미상환 금액 조회 (상환 완료된 것은 0으로 계산됨)
      */
-    @Query("SELECT SUM(e.supportAmount - e.repaidAmount) FROM ExchangeSupportFund e WHERE e.status IN ('ACTIVE', 'PARTIAL_REPAID', 'OVERDUE')")
+    @Query("SELECT SUM(e.supportAmount - e.repaidAmount) FROM ExchangeSupportFund e WHERE e.status IN ('ACTIVE', 'PARTIAL_REPAID', 'OVERDUE', 'REPAID')")
     BigDecimal getTotalUnpaidAmount();
 }

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/delisting/scheduler/DelistingScheduler.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/delisting/scheduler/DelistingScheduler.java
@@ -55,7 +55,7 @@ public class DelistingScheduler {
     
     /**
      * 매 분마다 상장폐지 자동 진행 체크
-     * - DELISTING_RISK: 3분 후 자동으로 DELISTING_NOTICE (예고 발행)
+     * - DELISTING_RISK: 10분 후 자동으로 DELISTING_NOTICE (예고 발행)
      * - DELISTING_NOTICE: 관리자가 수동으로 executeDelisting 실행 (환불 처리)
      */
     @Scheduled(fixedRate = 60000) // 1분마다
@@ -63,7 +63,7 @@ public class DelistingScheduler {
         log.debug("상장폐지 자동 진행 체크 시작");
         
         try {
-            // DELISTING_RISK → DELISTING_NOTICE 전환 (3분 후)
+            // DELISTING_RISK → DELISTING_NOTICE 전환 (10분 후)
             delistingService.processAutoDelisting();
             
             // DELISTING_NOTICE 이후는 관리자가 수동으로 처리

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/delisting/service/DelistingService.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/delisting/service/DelistingService.java
@@ -10,6 +10,7 @@ import com.beyond.MKX.domain.delisting.dto.DelistingProgressResDto;
 import com.beyond.MKX.domain.delisting.dto.ViolationSummaryDto;
 import com.beyond.MKX.domain.delisting.dto.CompensationStatusDto;
 import com.beyond.MKX.domain.delisting.entity.*;
+import com.beyond.MKX.domain.delisting.entity.DelistingCriteriaCode;
 import com.beyond.MKX.domain.delisting.repository.*;
 import com.beyond.MKX.domain.stock.entity.Stock;
 import com.beyond.MKX.domain.stock.repository.StockRepository;
@@ -27,6 +28,8 @@ import com.beyond.MKX.domain.delisting.entity.ExchangeSupportFund;
 import com.beyond.MKX.domain.account.accountlist.repository.AccountListRepository;
 import com.beyond.MKX.domain.account.accountlist.entity.AccountList;
 import com.beyond.MKX.domain.account.accountlist.entity.AccountType;
+import com.beyond.MKX.domain.ipo.ipo.entity.Ipo;
+import com.beyond.MKX.domain.ipo.ipo.repository.IpoRepository;
 import com.beyond.MKX.common.openai.OpenAiService;
 import com.beyond.MKX.common.kafka.event.TransactionEvent;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +43,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -73,6 +77,7 @@ public class DelistingService {
     private final ExchangeAccountRepository exchangeAccountRepo;
     private final ExchangeSupportFundRepository exchangeSupportFundRepo;
     private final AccountListRepository accountListRepo;
+    private final IpoRepository ipoRepo;
     private final OpenAiService openAiService;
     private final GptAnalysisService gptAnalysisService;
     
@@ -142,7 +147,7 @@ public class DelistingService {
 
         // 이력 기록
         recordHistory(stockId, ActionType.CRITERIA_VIOLATION, null, null, 
-                     "기준 위반 감지: " + criteriaCode, saved.getId().toString(), null);
+                     "기준 위반 감지: " + getCriteriaNameInKorean(criteriaCode), saved.getId().toString(), null);
 
         log.info("기준 위반 기록 완료: violationId={}, consecutivePeriods={}", 
                 saved.getId(), consecutivePeriods);
@@ -218,7 +223,7 @@ public class DelistingService {
 
         // 이력 기록
         recordHistory(stockId, ActionType.CRITERIA_VIOLATION, null, null, 
-                     "기준 위반 감지 (GPT 분석 포함): " + criteriaCode, saved.getId().toString(), null);
+                     "전문가 분석 기준 위반 감지: " + getCriteriaNameInKorean(criteriaCode), saved.getId().toString(), null);
 
         log.info("GPT 분석 결과 포함 기준 위반 기록 완료: violationId={}, consecutivePeriods={}, gptUsed={}", 
                 saved.getId(), consecutivePeriods, gptAnalysisUsed);
@@ -581,27 +586,49 @@ public class DelistingService {
                         compensationPrice = BigDecimal.valueOf(currentPrice.price());
                         log.info("현재가 조회 성공: ticker={}, price={}", ticker, compensationPrice);
                     } else {
-                        // 현재가 정보가 없으면 보상금 생성 중단하고 기록
-                        log.error("현재가 정보 없음으로 보상금 생성 중단: stockId={}, ticker={}", stockId, ticker);
+                        // 현재가 정보가 없으면 IPO 상장일 기준가로 대체 시도
+                        log.warn("현재가 정보 없음, IPO 상장일 기준가로 대체 시도: stockId={}, ticker={}", stockId, ticker);
+                        compensationPrice = getIpoListingPrice(stockId, ticker);
+                        if (compensationPrice == null) {
+                            log.error("현재가 및 IPO 기준가 정보 없음으로 보상금 생성 중단: stockId={}, ticker={}", stockId, ticker);
+                            recordCompensationFailure(stockId, ticker, "CURRENT_PRICE_NOT_FOUND", "현재가 정보가 없습니다");
+                            return;
+                        }
+                        log.info("IPO 상장일 기준가 사용: ticker={}, price={}", ticker, compensationPrice);
+                    }
+                } else {
+                    // 현재가 정보가 없으면 IPO 상장일 기준가로 대체 시도
+                    log.warn("현재가 정보 없음, IPO 상장일 기준가로 대체 시도: stockId={}, ticker={}", stockId, ticker);
+                    compensationPrice = getIpoListingPrice(stockId, ticker);
+                    if (compensationPrice == null) {
+                        log.error("현재가 및 IPO 기준가 정보 없음으로 보상금 생성 중단: stockId={}, ticker={}", stockId, ticker);
                         recordCompensationFailure(stockId, ticker, "CURRENT_PRICE_NOT_FOUND", "현재가 정보가 없습니다");
                         return;
                     }
-                } else {
-                    // 현재가 정보가 없으면 보상금 생성 중단하고 기록
-                    log.error("현재가 정보 없음으로 보상금 생성 중단: stockId={}, ticker={}", stockId, ticker);
-                    recordCompensationFailure(stockId, ticker, "CURRENT_PRICE_NOT_FOUND", "현재가 정보가 없습니다");
-                    return;
+                    log.info("IPO 상장일 기준가 사용: ticker={}, price={}", ticker, compensationPrice);
                 }
             } catch (Exception e) {
-                // marketdata 서비스 호출 실패 시 보상금 생성 중단하고 기록
-                log.error("현재가 조회 실패로 보상금 생성 중단: stockId={}, ticker={}", stockId, ticker, e);
-                recordCompensationFailure(stockId, ticker, "CURRENT_PRICE_FETCH_FAILED", "현재가 조회 실패: " + e.getMessage());
-                return;
+                // marketdata 서비스 호출 실패 시 IPO 상장일 기준가로 대체 시도
+                log.warn("현재가 조회 실패, IPO 상장일 기준가로 대체 시도: stockId={}, ticker={}, error={}", stockId, ticker, e.getMessage());
+                compensationPrice = getIpoListingPrice(stockId, ticker);
+                if (compensationPrice == null) {
+                    log.error("현재가 조회 실패 및 IPO 기준가 정보 없음으로 보상금 생성 중단: stockId={}, ticker={}", stockId, ticker, e);
+                    recordCompensationFailure(stockId, ticker, "CURRENT_PRICE_FETCH_FAILED", "현재가 조회 실패: " + e.getMessage());
+                    return;
+                }
+                log.info("IPO 상장일 기준가 사용 (현재가 조회 실패 후): ticker={}, price={}", ticker, compensationPrice);
             }
 
             // 총 보상금 계산
             BigDecimal totalCompensation = BigDecimal.ZERO;
             List<DelistingCompensation> compensations = new ArrayList<>();
+            
+            // compensationPrice가 null이면 안됨 (위에서 처리됨)
+            if (compensationPrice == null) {
+                log.error("보상 기준가가 null입니다: stockId={}, ticker={}", stockId, ticker);
+                recordCompensationFailure(stockId, ticker, "COMPENSATION_PRICE_NULL", "보상 기준가가 null입니다");
+                return;
+            }
 
             // 각 보유자별로 보상금 생성
             Map<UUID, String> accountNumberMap = new HashMap<>();
@@ -685,6 +712,44 @@ private void recordCompensationFailure(UUID stockId, String ticker, String failu
 
     } catch (Exception e) {
         log.error("보상금 실패 기록 저장 중 오류: stockId={}", stockId, e);
+    }
+}
+
+/**
+ * IPO 상장일 기준가 조회
+ * 현재가 정보가 없을 때 사용하는 fallback 메서드
+ */
+private BigDecimal getIpoListingPrice(UUID stockId, String ticker) {
+    try {
+        // 1. stockId로 먼저 조회 시도
+        Optional<Ipo> ipoByStockId = ipoRepo.findByStockId(stockId);
+        if (ipoByStockId.isPresent()) {
+            Ipo ipo = ipoByStockId.get();
+            if (ipo.getPriceOnListing() != null && ipo.getPriceOnListing() > 0) {
+                log.info("IPO 상장일 기준가 조회 성공 (stockId): stockId={}, ticker={}, price={}", 
+                        stockId, ticker, ipo.getPriceOnListing());
+                return BigDecimal.valueOf(ipo.getPriceOnListing());
+            }
+        }
+        
+        // 2. ticker로 조회 시도
+        if (ticker != null && !ticker.isEmpty()) {
+            Optional<Ipo> ipoByTicker = ipoRepo.findByStockTicker(ticker);
+            if (ipoByTicker.isPresent()) {
+                Ipo ipo = ipoByTicker.get();
+                if (ipo.getPriceOnListing() != null && ipo.getPriceOnListing() > 0) {
+                    log.info("IPO 상장일 기준가 조회 성공 (ticker): stockId={}, ticker={}, price={}", 
+                            stockId, ticker, ipo.getPriceOnListing());
+                    return BigDecimal.valueOf(ipo.getPriceOnListing());
+                }
+            }
+        }
+        
+        log.warn("IPO 상장일 기준가를 찾을 수 없음: stockId={}, ticker={}", stockId, ticker);
+        return null;
+    } catch (Exception e) {
+        log.error("IPO 상장일 기준가 조회 중 오류 발생: stockId={}, ticker={}", stockId, ticker, e);
+        return null;
     }
 }
 
@@ -840,7 +905,7 @@ public void retryFailedCompensations(UUID stockId) {
                     
                     // 삭제 내역을 이력에 기록
                     recordHistory(stockId, ActionType.DELISTING_EXECUTION, null, null,
-                                 "Stock holdings 삭제 완료 (재처리): " + deletedCount + "건", null, null);
+                                 "주식 소유권자 " + deletedCount + "명에 대한 보상처리 완료 (재처리)", null, null);
                 } else {
                     log.warn("Stock holdings 삭제 결과가 null (재처리): ticker={}", ticker);
                 }
@@ -899,7 +964,31 @@ public void executeDelisting(UUID stockId) {
         // ★ GPT 분석 결과에서 reason 가져오기
         DelistingReason delistingReason = extractAndMapDelistingReason(stockId);
         
-        // 주식 상태를 DELISTED로 변경
+        // ⚠️ 보상금 생성 및 지급을 먼저 시도 (상태 변경 전에)
+        boolean compensationSuccess = false;
+        try {
+            createCompensations(stockId);
+            compensationSuccess = true;
+            log.info("✅ 보상금 생성 및 지급 성공: stockId={}", stockId);
+        } catch (Exception e) {
+            log.error("❌ 보상금 생성 및 지급 실패: stockId={}, error={}", stockId, e.getMessage(), e);
+            
+            // 실패 이력 기록
+            recordHistory(stockId, ActionType.COMPENSATION_FAILED, currentStage, null,
+                         "보상금 처리 실패: " + e.getMessage(), null, null);
+            
+            // 보상금 실패 시 상장폐지 실행 중단 (상태 변경하지 않음)
+            log.error("보상금 실패로 인한 상장폐지 실행 중단: stockId={}, 상태는 DELISTING_PROCESS 유지", stockId);
+            throw new RuntimeException("보상금 처리 실패로 상장폐지 실행 중단: " + e.getMessage(), e);
+        }
+        
+        // ✅ 보상금 성공 후에만 상태 변경 및 Stock Holdings 삭제
+        if (!compensationSuccess) {
+            log.error("보상금 실패로 인해 상태 변경 및 Stock Holdings 삭제를 건너뜀: stockId={}", stockId);
+            throw new RuntimeException("보상금 처리 실패");
+        }
+        
+        // 주식 상태를 DELISTED로 변경 (보상금 성공 후에만)
         stock.updateStatus(Stock.Status.DELISTED);
         stock.setDelistingExecutionDate(LocalDateTime.now());
         stock.setDelistingStage(DelistingStage.DELISTED);
@@ -909,22 +998,7 @@ public void executeDelisting(UUID stockId) {
         log.info("주식 상태 변경 완료: stockId={}, stage: {} → DELISTED, reason={}", 
                 stockId, currentStage, delistingReason);
         
-        // 보상금 생성 및 지급 (MSA 연동)
-        try {
-            createCompensations(stockId);
-            log.info("✅ 보상금 생성 및 지급 성공: stockId={}", stockId);
-        } catch (Exception e) {
-            log.error("❌ 보상금 생성 및 지급 실패: stockId={}, error={}", stockId, e.getMessage(), e);
-            
-            // 실패 이력 기록
-            recordHistory(stockId, ActionType.COMPENSATION_FAILED, currentStage, null,
-                         "보상금 처리 실패: " + e.getMessage(), null, null);
-            
-            // 보상금 실패 시 상장폐지를 롤백하지 않고 예외를 throw
-            throw new RuntimeException("보상금 처리 실패: " + e.getMessage(), e);
-        }
-        
-        // ✅ Stock Holdings 삭제 (환불 완료 후)
+        // ✅ Stock Holdings 삭제 (보상금 완료 후에만)
         try {
             String ticker = stock.getTicker();
             log.info("Stock holdings 삭제 시작: ticker={}, stockId={}", ticker, stockId);
@@ -937,7 +1011,7 @@ public void executeDelisting(UUID stockId) {
                 
                 // 삭제 내역을 이력에 기록
                 recordHistory(stockId, ActionType.DELISTING_EXECUTION, null, null,
-                             "Stock holdings 삭제 완료: " + deletedCount + "건", null, null);
+                             "주식 소유권자 " + deletedCount + "명에 대한 보상처리 완료", null, null);
             } else {
                 log.warn("Stock holdings 삭제 결과가 null: ticker={}", ticker);
             }
@@ -972,6 +1046,87 @@ public void executeDelisting(UUID stockId) {
 
 // 스케줄러 중복 실행 방지를 위한 락
 private final AtomicBoolean isProcessingRetry = new AtomicBoolean(false);
+private final AtomicBoolean isProcessingDelistingRetry = new AtomicBoolean(false);
+
+/**
+ * 실패한 상장폐지 실행 재시도 스케줄러
+ * 매 5분마다 실행되어 보상금 실패로 중단된 상장폐지를 자동으로 재시도
+ */
+@Scheduled(fixedRate = 300000) // 5분마다 실행 (300,000ms = 5분)
+public void scheduledRetryFailedDelistings() {
+    // 이미 실행 중이면 스킵 (중복 실행 방지)
+    if (!isProcessingDelistingRetry.compareAndSet(false, true)) {
+        log.info("⏭️ 실패한 상장폐지 재시도가 이미 실행 중 - 이번 스케줄 스킵");
+        return;
+    }
+    
+    try {
+        log.info("실패한 상장폐지 자동 재시도 스케줄러 시작");
+        
+        // 1. DELISTING_PROCESS 상태인 주식 조회
+        List<Stock> processStocks = stockRepo.findByStatusIn(List.of(Stock.Status.DELISTING_PROCESS));
+        
+        if (processStocks.isEmpty()) {
+            log.info("재시도할 실패한 상장폐지 없음 - DELISTING_PROCESS 상태인 주식이 없습니다");
+            return;
+        }
+        
+        log.info("DELISTING_PROCESS 상태인 주식 발견: {}개", processStocks.size());
+        
+        // 2. 각 주식에 대해 COMPENSATION_FAILED 이력이 있는지 확인
+        List<Stock> failedDelistings = new ArrayList<>();
+        for (Stock stock : processStocks) {
+            List<DelistingHistory> failureRecords = historyRepo.findByStockIdAndActionTypeAndExecutionResult(
+                    stock.getId(), ActionType.COMPENSATION_FAILED, DelistingHistory.ExecutionResult.FAILED);
+            
+            if (!failureRecords.isEmpty()) {
+                // 최근 실패 기록 확인 (최근 1시간 이내)
+                LocalDateTime oneHourAgo = LocalDateTime.now().minusHours(1);
+                boolean recentFailure = failureRecords.stream()
+                        .anyMatch(record -> record.getExecutionDate().isAfter(oneHourAgo));
+                
+                if (recentFailure) {
+                    failedDelistings.add(stock);
+                    log.info("재시도 대상 발견: stockId={}, ticker={}, 실패 기록 수={}", 
+                            stock.getId(), stock.getTicker(), failureRecords.size());
+                }
+            }
+        }
+        
+        if (failedDelistings.isEmpty()) {
+            log.info("재시도할 실패한 상장폐지 없음 - 최근 실패 기록이 없습니다");
+            return;
+        }
+        
+        log.info("실패한 상장폐지 재시도 대상: {}개", failedDelistings.size());
+        
+        int successCount = 0;
+        int failureCount = 0;
+        
+        for (Stock stock : failedDelistings) {
+            try {
+                log.info("상장폐지 재시도 시작: stockId={}, ticker={}", stock.getId(), stock.getTicker());
+                executeDelisting(stock.getId());
+                successCount++;
+                log.info("✅ 상장폐지 재시도 성공: stockId={}, ticker={}", stock.getId(), stock.getTicker());
+            } catch (Exception e) {
+                failureCount++;
+                log.error("❌ 상장폐지 재시도 실패: stockId={}, ticker={}, error={}", 
+                        stock.getId(), stock.getTicker(), e.getMessage(), e);
+            }
+        }
+        
+        log.info("실패한 상장폐지 자동 재시도 완료: 성공 {}개 / 실패 {}개 / 전체 {}개", 
+                successCount, failureCount, failedDelistings.size());
+        
+    } catch (Exception e) {
+        log.error("실패한 상장폐지 자동 재시도 스케줄러 오류", e);
+    } finally {
+        // 락 해제
+        isProcessingDelistingRetry.set(false);
+        log.debug("상장폐지 재시도 스케줄러 락 해제");
+    }
+}
 
 /**
  * 실패한 보상금 자동 재처리 스케줄러
@@ -2469,6 +2624,20 @@ public void scheduledRetryFailedCompensations() {
             }
         } catch (Exception e) {
             log.error("GPT 분석 실행 실패: stockId={}, criteriaCode={}", stockId, criteria.getCriteriaCode(), e);
+        }
+    }
+
+    /**
+     * 기준 코드를 한국어 이름으로 변환
+     */
+    private String getCriteriaNameInKorean(String criteriaCode) {
+        try {
+            DelistingCriteriaCode codeEnum = DelistingCriteriaCode.fromCode(criteriaCode);
+            return codeEnum.getDescription();
+        } catch (IllegalArgumentException e) {
+            // 알 수 없는 코드인 경우 원본 반환
+            log.warn("알 수 없는 기준 코드: {}", criteriaCode);
+            return criteriaCode;
         }
     }
 

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/delisting/service/DelistingService.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/delisting/service/DelistingService.java
@@ -234,7 +234,7 @@ public class DelistingService {
     /**
      * 주식 상태를 상장폐지 위험으로 변경
      * 위반 감지 시 자동으로 DELISTING_RISK 상태로 변경
-     * 이후 3분 후 자동으로 DELISTING_PROCESS 상태로 전환
+     * 이후 10분 후 자동으로 DELISTING_NOTICE 상태로 전환
      */
     @Transactional
     private void updateStockStatusToRisk(UUID stockId) {
@@ -271,7 +271,7 @@ public class DelistingService {
                 log.info("주식 상태 업데이트 완료: stockId={}, status={}, stage={}", 
                         stockId, stock.getStatus(), stock.getDelistingStage());
                 
-                // 위반이 해결되지 않은 경우, 3분 후 자동으로 DELISTING_PROCESS로 전환
+                // 위반이 해결되지 않은 경우, 10분 후 자동으로 DELISTING_NOTICE로 전환
                 scheduleAutoDelistingProcess(stockId);
             }
         } catch (Exception e) {
@@ -280,12 +280,12 @@ public class DelistingService {
     }
     
     /**
-     * 3분 후 자동으로 DELISTING_PROCESS로 전환하는 스케줄러
+     * 10분 후 자동으로 DELISTING_NOTICE로 전환하는 스케줄러
      * 공시 미제출 시 자동 진행
      */
     private void scheduleAutoDelistingProcess(UUID stockId) {
         // 여기서는 단순히 기록만 하고, 별도의 스케줄러에서 처리
-        log.info("상장폐지 자동 진행 예약: stockId={}, 3분 후 DELISTING_PROCESS로 전환 예정", stockId);
+        log.info("상장폐지 자동 진행 예약: stockId={}, 10분 후 DELISTING_NOTICE로 전환 예정", stockId);
         // TODO: 별도 스케줄러에서 처리하거나, 이벤트 발행
     }
     
@@ -344,7 +344,7 @@ public class DelistingService {
             case LISTED, SUSPENDED -> DelistingStage.NORMAL;
             case DELISTING_RISK -> DelistingStage.WARNING;
             case DELISTING_NOTICE -> DelistingStage.DELISTING_NOTICE;
-            case DELISTING_PROCESS -> DelistingStage.DELISTING_PROCESS;
+            case DELISTING_PROCESS, DELISTING_DELAYED -> DelistingStage.DELISTING_PROCESS;
             case DELISTED -> DelistingStage.DELISTED;
         };
     }
@@ -534,11 +534,26 @@ public class DelistingService {
         log.info("보상금 생성 및 지급 시작: stockId={}", stockId);
 
         try {
+            // stockId로 Stock 엔티티 조회하여 ticker 가져오기 (먼저 조회)
+            Stock stock = stockRepo.findById(stockId)
+                    .orElseThrow(() -> new IllegalArgumentException("Stock not found: " + stockId));
+
             // ✅ 기존 보상금 확인 (중복 방지)
             List<DelistingCompensation> existingCompensations = compensationRepo.findByStockId(stockId);
             if (!existingCompensations.isEmpty()) {
                 log.info("이미 생성된 보상금이 존재: stockId={}, count={}", 
                         stockId, existingCompensations.size());
+                
+                // 기존 보상금의 총액 계산하여 Stock에 저장 (이미 계산된 값이 없을 수 있음)
+                BigDecimal existingTotal = existingCompensations.stream()
+                    .map(DelistingCompensation::getCompensationAmount)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+                
+                if (stock.getTotalCompensationAmount() == null || stock.getTotalCompensationAmount().compareTo(existingTotal) != 0) {
+                    stock.setTotalCompensationAmount(existingTotal);
+                    stockRepo.save(stock);
+                    log.info("기존 보상금 총액 저장: stockId={}, totalCompensation={}", stockId, existingTotal);
+                }
                 
                 // 모든 보상금이 완료되었는지 확인
                 boolean allCompleted = existingCompensations.stream()
@@ -552,10 +567,6 @@ public class DelistingService {
                 log.info("미완료 보상금 존재 - 새로운 보상금 생성하지 않고 종료: stockId={}", stockId);
                 return; // 기존 미완료 보상금 재처리는 retryFailedCompensations에서 처리
             }
-            
-            // stockId로 Stock 엔티티 조회하여 ticker 가져오기
-            Stock stock = stockRepo.findById(stockId)
-                    .orElseThrow(() -> new IllegalArgumentException("Stock not found: " + stockId));
 
             String ticker = stock.getTicker();
             log.info("주식 정보 조회: stockId={}, ticker={}", stockId, ticker);
@@ -672,6 +683,11 @@ public class DelistingService {
             // 실제 지급 처리 (3단계 방식)
             processCompensationPayment(stockId, compensations, totalCompensation, accountNumberMap);
 
+            // 총 보상금을 Stock 엔티티에 저장
+            stock.setTotalCompensationAmount(totalCompensation);
+            stockRepo.save(stock);
+            log.info("총 보상금 저장 완료: stockId={}, totalCompensation={}", stockId, totalCompensation);
+
             log.info("보상금 생성 및 지급 완료: stockId={}, 보유자 수={}, 총 보상금={}", 
                     stockId, holders.size(), totalCompensation);
 
@@ -684,6 +700,8 @@ public class DelistingService {
             } catch (Exception ex) {
                 log.error("실패 기록 저장 중 오류: stockId={}", stockId, ex);
             }
+            // 예외를 다시 던져서 상장폐지 실행을 중단시킴
+            throw new RuntimeException("보상금 생성 실패: " + e.getMessage(), e);
         }
     }
 
@@ -973,13 +991,38 @@ public void executeDelisting(UUID stockId) {
         } catch (Exception e) {
             log.error("❌ 보상금 생성 및 지급 실패: stockId={}, error={}", stockId, e.getMessage(), e);
             
+            // 보상금이 생성되었지만 지급 실패한 경우, 총 보상금을 Stock에 저장
+            List<DelistingCompensation> createdCompensations = compensationRepo.findByStockId(stockId);
+            if (!createdCompensations.isEmpty()) {
+                BigDecimal totalCompensation = createdCompensations.stream()
+                    .map(DelistingCompensation::getCompensationAmount)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+                stock.setTotalCompensationAmount(totalCompensation);
+                log.info("보상금 생성 완료 (지급 실패): stockId={}, totalCompensation={}", stockId, totalCompensation);
+            }
+            
             // 실패 이력 기록
             recordHistory(stockId, ActionType.COMPENSATION_FAILED, currentStage, null,
                          "보상금 처리 실패: " + e.getMessage(), null, null);
             
-            // 보상금 실패 시 상장폐지 실행 중단 (상태 변경하지 않음)
-            log.error("보상금 실패로 인한 상장폐지 실행 중단: stockId={}, 상태는 DELISTING_PROCESS 유지", stockId);
-            throw new RuntimeException("보상금 처리 실패로 상장폐지 실행 중단: " + e.getMessage(), e);
+            // 거래소 계좌 잔액 부족 여부 확인
+            boolean isExchangeBalanceShortage = e.getMessage() != null && 
+                (e.getMessage().contains("거래소 계좌 잔액이 부족") || 
+                 e.getMessage().contains("잔액이 부족합니다"));
+            
+            // 거래소 잔액 부족인 경우 DELISTING_DELAYED 상태로 변경하고 정상 종료
+            if (isExchangeBalanceShortage) {
+                stock.updateStatus(Stock.Status.DELISTING_DELAYED);
+                stockRepo.save(stock);
+                log.warn("거래소 계좌 잔액 부족으로 인한 상장폐지 지연: stockId={}, 상태를 DELISTING_DELAYED로 변경", stockId);
+                // 상태 변경 완료했으므로 정상 종료 (예외를 던지지 않음)
+                return;
+            } else {
+                // 다른 이유로 실패한 경우 기존 상태 유지하고 예외 발생
+                log.error("보상금 실패로 인한 상장폐지 실행 중단: stockId={}, 상태는 {} 유지", 
+                         stockId, stock.getStatus());
+                throw new RuntimeException("보상금 처리 실패로 상장폐지 실행 중단: " + e.getMessage(), e);
+            }
         }
         
         // ✅ 보상금 성공 후에만 상태 변경 및 Stock Holdings 삭제
@@ -1063,15 +1106,16 @@ public void scheduledRetryFailedDelistings() {
     try {
         log.info("실패한 상장폐지 자동 재시도 스케줄러 시작");
         
-        // 1. DELISTING_PROCESS 상태인 주식 조회
-        List<Stock> processStocks = stockRepo.findByStatusIn(List.of(Stock.Status.DELISTING_PROCESS));
+        // 1. DELISTING_PROCESS 또는 DELISTING_DELAYED 상태인 주식 조회
+        List<Stock> processStocks = stockRepo.findByStatusIn(
+            List.of(Stock.Status.DELISTING_PROCESS, Stock.Status.DELISTING_DELAYED));
         
         if (processStocks.isEmpty()) {
-            log.info("재시도할 실패한 상장폐지 없음 - DELISTING_PROCESS 상태인 주식이 없습니다");
+            log.info("재시도할 실패한 상장폐지 없음 - DELISTING_PROCESS 또는 DELISTING_DELAYED 상태인 주식이 없습니다");
             return;
         }
         
-        log.info("DELISTING_PROCESS 상태인 주식 발견: {}개", processStocks.size());
+        log.info("DELISTING_PROCESS 또는 DELISTING_DELAYED 상태인 주식 발견: {}개", processStocks.size());
         
         // 2. 각 주식에 대해 COMPENSATION_FAILED 이력이 있는지 확인
         List<Stock> failedDelistings = new ArrayList<>();
@@ -1234,6 +1278,51 @@ public void scheduledRetryFailedCompensations() {
                 .build();
 
         historyRepo.save(history);
+    }
+
+    /**
+     * 위험 해소 처리: 미해결 위반 해지 및 주식 상태 정상화
+     */
+    @Transactional
+    public void resolveRisk(UUID stockId, UUID adminId, String reason) {
+        log.info("위험 해소 처리 시작: stockId={}, adminId={}, reason={}", stockId, adminId, reason);
+
+        Stock stock = stockRepo.findById(stockId)
+                .orElseThrow(() -> new IllegalArgumentException("Stock not found: " + stockId));
+
+        // DELISTING_RISK 상태가 아니면 처리하지 않음
+        if (stock.getStatus() != Stock.Status.DELISTING_RISK) {
+            log.warn("위험 해소 대상이 아님: stockId={}, status={}", stockId, stock.getStatus());
+            throw new IllegalArgumentException("상장폐지 위험 상태가 아닙니다: " + stock.getStatus());
+        }
+
+        // 1) 미해결 위반 모두 해지 처리
+        List<DelistingViolation> unresolved = violationRepo.findByStockIdAndUnresolved(stockId);
+        if (!unresolved.isEmpty()) {
+            for (DelistingViolation v : unresolved) {
+                v.setIsResolved(true);
+                v.setResolvedDate(LocalDateTime.now());
+                v.setResolvedBy(adminId);
+                String prev = v.getDescription() != null ? v.getDescription() + "\n" : "";
+                v.setDescription(prev + "[수동 처리] 위험 해소: " + (reason != null ? reason : "문제 없음으로 판단"));
+                violationRepo.save(v);
+            }
+            // 위반 해지 이력
+            String ids = unresolved.stream().map(x -> x.getId().toString()).reduce((a,b)->a+","+b).orElse("");
+            recordHistory(stockId, ActionType.CRITERIA_VIOLATION, null, null,
+                "위험 해소 처리로 미해결 위반 해지: " + (reason != null ? reason : "문제 없음으로 판단"), ids, adminId);
+        }
+
+        // 2) 주식 상태 정상화
+        DelistingStage fromStage = stock.getDelistingStage();
+        Stock.Status prevStatus = stock.getStatus();
+        stock.updateStatus(Stock.Status.LISTED);
+        stock.setDelistingStage(DelistingStage.NORMAL);
+        stockRepo.save(stock);
+
+        log.info("주식 상태 정상화: stockId={}, {}→LISTED, stage {}→NORMAL", stockId, prevStatus, fromStage);
+        recordHistory(stockId, ActionType.STAGE_CHANGE, fromStage, DelistingStage.NORMAL,
+            "위험 해소 처리로 상태 정상화: " + (reason != null ? reason : "문제 없음으로 판단"), null, adminId);
     }
 
     /**
@@ -1829,6 +1918,8 @@ public void scheduledRetryFailedCompensations() {
         } catch (Exception e) {
             log.error("보상금 지급 처리 중 오류: stockId={}", stockId, e);
             recordCompensationFailure(stockId, "PAYMENT_PROCESSING_FAILED", "지급 처리 실패: " + e.getMessage());
+            // 예외를 다시 던져서 상장폐지 실행을 중단시킴
+            throw new RuntimeException("보상금 지급 처리 실패: " + e.getMessage(), e);
         }
     }
 
@@ -1880,10 +1971,16 @@ public void scheduledRetryFailedCompensations() {
     private void processExchangeFunding(UUID stockId, UUID corporationId, BigDecimal shortage) {
         log.info("거래소 funding 처리 시작: stockId={}, shortage={}", stockId, shortage);
         
-        // 거래소 계좌에서 출금
-        ExchangeAccount exchangeAccount = getExchangeAccount();
-        exchangeAccount.withdraw(shortage.toBigInteger());
-        exchangeAccountRepo.save(exchangeAccount);
+        try {
+            // 거래소 계좌에서 출금
+            ExchangeAccount exchangeAccount = getExchangeAccount();
+            exchangeAccount.withdraw(shortage.toBigInteger());
+            exchangeAccountRepo.save(exchangeAccount);
+        } catch (IllegalArgumentException e) {
+            // 거래소 계좌 잔액 부족 시 예외 발생
+            log.error("거래소 계좌 잔액 부족: stockId={}, shortage={}, error={}", stockId, shortage, e.getMessage());
+            throw new RuntimeException("거래소 계좌 잔액이 부족하여 보상금 지급이 불가능합니다. 상장폐지 처리가 지연됩니다: " + e.getMessage(), e);
+        }
         
         // ExchangeSupportFund 레코드 생성
         ExchangeSupportFund supportFund = ExchangeSupportFund.builder()
@@ -2901,11 +2998,11 @@ public void scheduledRetryFailedCompensations() {
                         continue;
                     }
                     
-                    // 위반 발생 후 3분 지났는지 확인
-                    LocalDateTime threeMinutesAgo = LocalDateTime.now().minusMinutes(3);
+                    // 위반 발생 후 10분 지났는지 확인
+                    LocalDateTime tenMinutesAgo = LocalDateTime.now().minusMinutes(10);
                     
-                    if (oldestViolation.getViolationDate().isBefore(threeMinutesAgo)) {
-                        log.info("3분 유예기간 경과: stockId={}, violationDate={}, 전환 대상", 
+                    if (oldestViolation.getViolationDate().isBefore(tenMinutesAgo)) {
+                        log.info("10분 유예기간 경과: stockId={}, violationDate={}, 전환 대상", 
                                 stock.getId(), oldestViolation.getViolationDate());
                         
                         // 현재 stage 확인
@@ -2923,7 +3020,7 @@ public void scheduledRetryFailedCompensations() {
                             // 이력 기록
                             recordHistory(stock.getId(), ActionType.STAGE_CHANGE, 
                                          DelistingStage.WARNING, DelistingStage.DELISTING_NOTICE,
-                                         "3분 유예기간 경과 - 예고 발행", 
+                                         "10분 유예기간 경과 - 예고 발행", 
                                          oldestViolation.getId().toString(), null);
                             
                             processedCount++;

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/financial/entity/FinancialRatios.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/financial/entity/FinancialRatios.java
@@ -27,7 +27,7 @@ public class FinancialRatios extends BaseIdAndTimeEntity {
 
     @Column(name="per",               precision=10, scale=2) private BigDecimal per;
     @Column(name="pbr",               precision=10, scale=2) private BigDecimal pbr;
-    @Column(name="bps",               precision=10, scale=2) private BigDecimal bps;  // 주당순자산가치
+    @Column(name="bps",               precision=18, scale=2) private BigDecimal bps;  // 주당순자산가치 (큰 값 지원)
     @Column(name="operating_margin",  precision=10, scale=2) private BigDecimal operatingMargin;
     @Column(name="net_margin",        precision=10, scale=2) private BigDecimal netMargin;
     @Column(name="debt_ratio",        precision=10, scale=2) private BigDecimal debtRatio;

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/financial/util/FinancialRatiosAutoCalculator.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/financial/util/FinancialRatiosAutoCalculator.java
@@ -86,14 +86,20 @@ public class FinancialRatiosAutoCalculator {
     /**
      * BPS(주당순자산가치) = 자기자본 / 총발행주식수
      * - 총발행주식수가 0이면 0.00 반환
+     * - 큰 값 지원을 위해 BigDecimal 직접 사용
      */
     public BigDecimal calculateBPS(CompanyFinancials cf, Long totalSharesOutstanding) {
         if (totalSharesOutstanding == null || totalSharesOutstanding == 0) {
             return BigDecimal.ZERO;
         }
-        double equity = toDouble(cf.getTotalEquity());
-        return BigDecimal.valueOf(equity / totalSharesOutstanding)
-            .setScale(2, RoundingMode.HALF_UP);
+        Long equity = cf.getTotalEquity();
+        if (equity == null || equity == 0) {
+            return BigDecimal.ZERO;
+        }
+        // BigDecimal을 직접 사용하여 정밀도 보장
+        BigDecimal equityBigDecimal = BigDecimal.valueOf(equity);
+        BigDecimal sharesBigDecimal = BigDecimal.valueOf(totalSharesOutstanding);
+        return equityBigDecimal.divide(sharesBigDecimal, 2, RoundingMode.HALF_UP);
     }
 
     /** Long → double null-safe 변환 */

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/ipo/ipo/repository/IpoRepository.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/ipo/ipo/repository/IpoRepository.java
@@ -84,4 +84,8 @@ public interface IpoRepository extends JpaRepository<Ipo, UUID> {
     List<Ipo> findByCorporationIdOrderByRequestedAtDesc(@Param("corporationId") UUID corporationId);
 
     boolean existsByCorporation_IdAndStatusIn(UUID corporationId, Collection<IpoStatus> statuses);
+
+    Optional<Ipo> findByStockId(UUID stockId);
+
+    Optional<Ipo> findByStockTicker(String ticker);
 }

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/stock/dto/StockListResDto.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/stock/dto/StockListResDto.java
@@ -14,6 +14,7 @@ public record StockListResDto(
         String nameKo,
         String status,
         String delistingStage,
+        String delistingReason,
         long totalSharesOutstanding,
         Long ownedShares,
         Long freeFloatShares,
@@ -29,6 +30,7 @@ public record StockListResDto(
                 .nameKo(s.getNameKo())
                 .status(s.getStatus() != null ? s.getStatus().name() : null)
                 .delistingStage(s.getDelistingStage() != null ? s.getDelistingStage().name() : null)
+                .delistingReason(s.getDelistingReason() != null ? s.getDelistingReason().name() : null)
                 .totalSharesOutstanding(s.getTotalSharesOutstanding())
                 .ownedShares(s.getOwnedShares())
                 .freeFloatShares(s.getFreeFloatShares())

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/stock/dto/StockListResDto.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/stock/dto/StockListResDto.java
@@ -3,6 +3,7 @@ package com.beyond.MKX.domain.stock.dto;
 import com.beyond.MKX.domain.stock.entity.Stock;
 import lombok.Builder;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -20,7 +21,8 @@ public record StockListResDto(
         Long freeFloatShares,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
-        LocalDateTime deletedAt
+        LocalDateTime deletedAt,
+        BigDecimal totalCompensationAmount
 ) {
     public static StockListResDto from(Stock s) {
         return StockListResDto.builder()
@@ -37,6 +39,7 @@ public record StockListResDto(
                 .createdAt(s.getCreatedAt())
                 .updatedAt(s.getUpdatedAt())
                 .deletedAt(s.getDeletedAt())
+                .totalCompensationAmount(s.getTotalCompensationAmount())
                 .build();
     }
 }

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/stock/entity/Stock.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/stock/entity/Stock.java
@@ -6,6 +6,7 @@ import com.beyond.MKX.domain.delisting.entity.DelistingStage;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -42,6 +43,7 @@ public class Stock extends BaseIdAndTimeEntity {
         DELISTING_RISK,            // 상장폐지 위험 (기준 위반)
         DELISTING_NOTICE,          // 상장폐지 예고
         DELISTING_PROCESS,         // 상장폐지 절차 진행 중
+        DELISTING_DELAYED,         // 상장폐지 지연 (보상금 지급 지연)
         DELISTED                   // 상장폐지 완료
     }
 
@@ -78,6 +80,10 @@ public class Stock extends BaseIdAndTimeEntity {
     @Enumerated(EnumType.STRING)
     private DelistingReason delistingReason;
 
+    // 상장폐지 보상금 총액 (상장폐지 실행 시 계산하여 저장)
+    @Column(name = "total_compensation_amount", precision = 20, scale = 2)
+    private BigDecimal totalCompensationAmount;
+
     // ====== 도메인 메서드(선택적 변경만 허용) ======
     public void updateNameKo(String nameKo) {
         this.nameKo = nameKo;
@@ -109,6 +115,10 @@ public class Stock extends BaseIdAndTimeEntity {
 
     public void setDelistingReason(DelistingReason delistingReason) {
         this.delistingReason = delistingReason;
+    }
+
+    public void setTotalCompensationAmount(BigDecimal totalCompensationAmount) {
+        this.totalCompensationAmount = totalCompensationAmount;
     }
 
     public void softDelete(LocalDateTime deletedAt) {


### PR DESCRIPTION
## 📋 작업 개요
상장폐지 및 지원금 관련 통계·보상 로직 전반 개선 및 안정화

<br/>

## 🔧 작업 상세
- **지원금 합계 통계 정확도 개선**
  - `ExchangeSupportFundRepository`의 총 지원금 합계 쿼리에 `'REPAID'` 상태 포함
  - 완전 상환된 지원금도 총액에 반영되도록 수정하여 기업별·거래소별 통계 정확도 향상

- **상장폐지 보상 처리 로직 보강**
  - 현재가 정보가 없을 경우 **IPO 상장일 기준가**를 fallback으로 사용하도록 수정
  - 보상 실패 시 상태 롤백 방지 및 `StockHoldings` 삭제 타이밍 조정
  - 실패한 상장폐지 자동 재시도 **스케줄러(5분 간격)** 추가로 안정성 강화
  - 보상 처리 이력 메시지 한글화 ("보상처리 완료", "기준 위반 감지" 등)

- **응답 데이터 확장 및 관리 기능 개선**
  - `StockListResDto`에 `delistingReason` 필드 추가 → 폐지 사유가 프론트에서 표시되도록 개선
  - 상장폐지 위험 해소 엔드포인트 추가 및 자동 예고 **유예기간 3분 → 10분**으로 연장

<br/>

## 📌 이슈 번호
close #118  

<br/>

## 🧪 테스트 결과
- Postman을 통한 상장폐지 절차 및 보상 처리 시나리오 테스트 완료  
- REPAID 상태 포함 후 거래소별·기업별 통계 API 응답 검증  
- 상장폐지 실패 후 자동 재시도 동작 정상 확인 (5분 주기)  
- 위험 해소 및 유예기간 연장 로직 동작 정상  
- 단위 테스트 및 통합 테스트 전부 통과

<br/>

## ⚠️ 참고사항
- 스케줄러 간격(5분)은 추후 운영 환경에서 트래픽 부하 및 처리량에 따라 조정 가능  
- 보상 실패 시 알림 로그 추가 예정  

<br/>

## 👥 리뷰어 지정
@AstroJini @ggj0228 

<br/>

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  
- [x] develop 브랜치로부터 최신 Pull 및 충돌 확인 완료했습니다.  
- [x] 테스트 검증 및 결과 자료 첨부를 완료했습니다.  
- [x] 최소 2명의 리뷰어를 지정했습니다.  
