### PR TITLE
[Feat] 증권사 대시보드 API 전면 구현 및 통계 개선 [임시 적용] (#122)

### DIFF
--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/member/dto/MemberAccountAdminSummaryDto.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/member/dto/MemberAccountAdminSummaryDto.java
@@ -17,5 +17,6 @@ public class MemberAccountAdminSummaryDto {
     private String email;
     private String accountNumber; // 회원 계좌번호
     private String accountStatus; // 회원 계좌 상태
+    private Long accountBalance; // 계좌 잔고
 }
 

--- a/mkx-platform/src/main/java/com/beyond/MKX/domain/member/service/MemberService.java
+++ b/mkx-platform/src/main/java/com/beyond/MKX/domain/member/service/MemberService.java
@@ -128,12 +128,23 @@ public class MemberService {
                 MemberAccountInternalClient.MemberAccountSummaryRes acc = memberAccountInternalClient.getByMember(m.getId());
                 String accNo = acc != null ? acc.accountNumber() : null;
                 String accStatus = acc != null ? acc.status() : null;
+                
+                // 잔고 정보를 위해 상세 조회 시도
+                Long balance = null;
+                try {
+                    MemberAccountInternalClient.MemberAccountDetailRes detailAcc = memberAccountInternalClient.getDetailByMember(m.getId());
+                    balance = detailAcc != null ? detailAcc.balance() : null;
+                } catch (Exception ignore) {
+                    // 상세 조회 실패 시 잔고는 null 유지
+                }
+                
                 return MemberAccountAdminSummaryDto.builder()
                         .memberId(m.getId())
                         .name(m.getName())
                         .email(m.getEmail())
                         .accountNumber(accNo)
                         .accountStatus(accStatus)
+                        .accountBalance(balance)
                         .build();
             } catch (Exception ignore) {
                 return MemberAccountAdminSummaryDto.builder()
@@ -142,6 +153,7 @@ public class MemberService {
                         .email(m.getEmail())
                         .accountNumber(null)
                         .accountStatus(null)
+                        .accountBalance(null)
                         .build();
             }
         }).filter(dto -> {

--- a/ordering/src/main/java/com/beyond/MKX/domain/assets/repository/StockHoldingRepository.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/assets/repository/StockHoldingRepository.java
@@ -20,4 +20,9 @@ public interface StockHoldingRepository extends JpaRepository<StockHolding, UUID
      */
     @Query("SELECT sh FROM StockHolding sh WHERE sh.ticker = :ticker AND sh.totalQuantity > 0")
     List<StockHolding> findAllByTicker(@Param("ticker") String ticker);
+
+    /**
+     * 증권사별 보유 종목 조회
+     */
+    List<StockHolding> findAllByBrokerageId(UUID brokerageId);
 }

--- a/ordering/src/main/java/com/beyond/MKX/domain/brokerage/controller/BrokerageDashboardController.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/brokerage/controller/BrokerageDashboardController.java
@@ -1,0 +1,185 @@
+package com.beyond.MKX.domain.brokerage.controller;
+
+import com.beyond.MKX.common.apiResponse.ApiResponse;
+import com.beyond.MKX.domain.account.admin.client.AdminInternalClient;
+import com.beyond.MKX.domain.brokerage.dto.BrokerageStatsDTO;
+import com.beyond.MKX.domain.brokerage.dto.LedgerDTO;
+import com.beyond.MKX.domain.brokerage.dto.OrderLogDTO;
+import com.beyond.MKX.domain.brokerage.dto.PopularStockDTO;
+import com.beyond.MKX.domain.brokerage.dto.RecentActivityDTO;
+import com.beyond.MKX.domain.brokerage.service.BrokerageDashboardService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 증권사 대시보드 API
+ * - 증권사 관리자용 대시보드 데이터 조회
+ */
+@RestController
+@RequestMapping("/api/brokerage/dashboard")
+@RequiredArgsConstructor
+@Slf4j
+public class BrokerageDashboardController {
+
+    private final BrokerageDashboardService brokerageDashboardService;
+    private final AdminInternalClient adminInternalClient;
+
+    /**
+     * 증권사별 통계 조회 (일일 거래량, 월간 수익 등)
+     * 
+     * @param adminId X-User-Id 헤더 (관리자 UUID)
+     * @return 통계 데이터
+     */
+    @GetMapping("/stats")
+    public ResponseEntity<?> getBrokerageStats(
+            @RequestHeader(value = "X-User-Id", required = false) String adminId
+    ) {
+        try {
+            if (adminId == null || adminId.isBlank()) {
+                return ResponseEntity.badRequest().body(Map.of("message", "X-User-Id 헤더가 필요합니다."));
+            }
+            UUID brokerageId = getBrokerageId(UUID.fromString(adminId));
+            BrokerageStatsDTO stats = brokerageDashboardService.getBrokerageStats(brokerageId);
+            return ApiResponse.ok(stats, "통계 조회 성공");
+        } catch (Exception e) {
+            log.error("Failed to get brokerage stats: {}", e.getMessage(), e);
+            return ResponseEntity.badRequest().body(Map.of("message", "통계 조회 실패: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * 증권사별 최근 활동 목록 조회 (order_log + ledger 통합)
+     * 
+     * @param adminId X-User-Id 헤더 (관리자 UUID)
+     * @param limit 최대 조회 개수 (기본값: 20)
+     * @return 최근 활동 목록
+     */
+    @GetMapping("/recent-activities")
+    public ResponseEntity<?> getRecentActivities(
+            @RequestHeader(value = "X-User-Id", required = false) String adminId,
+            @RequestParam(defaultValue = "20") int limit
+    ) {
+        try {
+            if (adminId == null || adminId.isBlank()) {
+                return ResponseEntity.badRequest().body(Map.of("message", "X-User-Id 헤더가 필요합니다."));
+            }
+            UUID brokerageId = getBrokerageId(UUID.fromString(adminId));
+            List<RecentActivityDTO> activities = brokerageDashboardService.getRecentActivities(brokerageId, limit);
+            return ApiResponse.ok(activities, "최근 활동 목록 조회 성공");
+        } catch (Exception e) {
+            log.error("Failed to get recent activities for brokerage: {}", e.getMessage(), e);
+            return ResponseEntity.badRequest().body(Map.of("message", "최근 활동 목록 조회 실패: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * 증권사별 인기 종목 조회 (보유 고객 수 기준)
+     * 
+     * @param adminId X-User-Id 헤더 (관리자 UUID)
+     * @param limit 최대 조회 개수 (기본값: 10)
+     * @return 인기 종목 목록
+     */
+    @GetMapping("/popular-stocks")
+    public ResponseEntity<?> getPopularStocks(
+            @RequestHeader(value = "X-User-Id", required = false) String adminId,
+            @RequestParam(defaultValue = "10") int limit
+    ) {
+        try {
+            if (adminId == null || adminId.isBlank()) {
+                return ResponseEntity.badRequest().body(Map.of("message", "X-User-Id 헤더가 필요합니다."));
+            }
+            UUID brokerageId = getBrokerageId(UUID.fromString(adminId));
+            List<PopularStockDTO> popularStocks = brokerageDashboardService.getPopularStocks(brokerageId, limit);
+            return ApiResponse.ok(popularStocks, "인기 종목 조회 성공");
+        } catch (Exception e) {
+            log.error("Failed to get popular stocks for brokerage: {}", e.getMessage(), e);
+            return ResponseEntity.badRequest().body(Map.of("message", "인기 종목 조회 실패: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * 증권사별 주문 내역 조회
+     * 
+     * @param adminId X-User-Id 헤더 (관리자 UUID)
+     * @param page 페이지 번호 (기본값: 0)
+     * @param size 페이지 크기 (기본값: 20)
+     * @return 주문 내역 페이지
+     */
+    @GetMapping("/order-logs")
+    public ResponseEntity<?> getOrderLogs(
+            @RequestHeader(value = "X-User-Id", required = false) String adminId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        try {
+            if (adminId == null || adminId.isBlank()) {
+                return ResponseEntity.badRequest().body(Map.of("message", "X-User-Id 헤더가 필요합니다."));
+            }
+            UUID brokerageId = getBrokerageId(UUID.fromString(adminId));
+            Pageable pageable = PageRequest.of(page, size);
+            Page<OrderLogDTO> orderLogs = brokerageDashboardService.getOrderLogs(brokerageId, pageable);
+            return ApiResponse.ok(orderLogs, "주문 내역 조회 성공");
+        } catch (Exception e) {
+            log.error("Failed to get order logs for brokerage: {}", e.getMessage(), e);
+            return ResponseEntity.badRequest().body(Map.of("message", "주문 내역 조회 실패: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * 증권사별 거래내역 조회
+     * 
+     * @param adminId X-User-Id 헤더 (관리자 UUID)
+     * @param page 페이지 번호 (기본값: 0)
+     * @param size 페이지 크기 (기본값: 20)
+     * @return 거래내역 페이지
+     */
+    @GetMapping("/ledgers")
+    public ResponseEntity<?> getLedgers(
+            @RequestHeader(value = "X-User-Id", required = false) String adminId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        try {
+            if (adminId == null || adminId.isBlank()) {
+                return ResponseEntity.badRequest().body(Map.of("message", "X-User-Id 헤더가 필요합니다."));
+            }
+            UUID brokerageId = getBrokerageId(UUID.fromString(adminId));
+            Pageable pageable = PageRequest.of(page, size);
+            Page<LedgerDTO> ledgers = brokerageDashboardService.getLedgers(brokerageId, pageable);
+            return ApiResponse.ok(ledgers, "거래내역 조회 성공");
+        } catch (Exception e) {
+            log.error("Failed to get ledgers for brokerage: {}", e.getMessage(), e);
+            return ResponseEntity.badRequest().body(Map.of("message", "거래내역 조회 실패: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * 관리자 ID로 증권사 ID 조회
+     */
+    private UUID getBrokerageId(UUID adminId) {
+        try {
+            AdminInternalClient.BrokerageIdRes res = adminInternalClient.getBrokerageId(adminId);
+            if (res == null || res.brokerageId() == null) {
+                throw new IllegalArgumentException("증권사 소속 관리자가 아닙니다.");
+            }
+            return res.brokerageId();
+        } catch (Exception e) {
+            log.error("Failed to get brokerage ID for admin {}: {}", adminId, e.getMessage());
+            throw new IllegalArgumentException("증권사 ID 조회 실패: " + e.getMessage());
+        }
+    }
+}
+

--- a/ordering/src/main/java/com/beyond/MKX/domain/brokerage/dto/BrokerageStatsDTO.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/brokerage/dto/BrokerageStatsDTO.java
@@ -1,0 +1,25 @@
+package com.beyond.MKX.domain.brokerage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 증권사 대시보드 통계 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BrokerageStatsDTO {
+    private Long totalCustomers; // 총 고객 수 (해당 증권사를 사용하는 총 회원 수)
+    private Long activeAccounts; // 활성 계좌 수 (APPROVED/ACTIVE 상태의 계좌 수)
+    private Long onlineCustomers; // 실시간 온라인 고객 수 (TODO: 실제 온라인 사용자 수 추적 필요)
+    private Long dailyVolume; // 일일 거래량 (오늘 날짜의 거래 금액 합계)
+    private Long monthlyRevenue; // 월간 수익 (이번 달의 수수료 합계)
+    private Long buyCommission; // 매수 수수료 (이번 달)
+    private Long sellCommission; // 매도 수수료 (이번 달)
+    private Double volumeChangePercent; // 거래량 변화율 (전날 대비)
+    private Double revenueChangePercent; // 수익 변화율 (전월 대비)
+}

--- a/ordering/src/main/java/com/beyond/MKX/domain/brokerage/dto/BrokerageStatsDTO.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/brokerage/dto/BrokerageStatsDTO.java
@@ -22,4 +22,6 @@ public class BrokerageStatsDTO {
     private Long sellCommission; // 매도 수수료 (이번 달)
     private Double volumeChangePercent; // 거래량 변화율 (전날 대비)
     private Double revenueChangePercent; // 수익 변화율 (전월 대비)
+    private Long customerChange; // 7일간 고객 수 변화
+    private Long accountChange; // 7일간 계좌 수 변화
 }

--- a/ordering/src/main/java/com/beyond/MKX/domain/brokerage/dto/BrokerageStatsDTO.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/brokerage/dto/BrokerageStatsDTO.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 public class BrokerageStatsDTO {
     private Long totalCustomers; // 총 고객 수 (해당 증권사를 사용하는 총 회원 수)
     private Long activeAccounts; // 활성 계좌 수 (APPROVED/ACTIVE 상태의 계좌 수)
-    private Long onlineCustomers; // 실시간 온라인 고객 수 (TODO: 실제 온라인 사용자 수 추적 필요)
+    private Long onlineCustomers; // 오늘 주문 고객 수 (오늘 00:00 ~ 23:59:59 안에 주문을 넣은 회원 계좌 수)
     private Long dailyVolume; // 일일 거래량 (오늘 날짜의 거래 금액 합계)
     private Long monthlyRevenue; // 월간 수익 (이번 달의 수수료 합계)
     private Long buyCommission; // 매수 수수료 (이번 달)

--- a/ordering/src/main/java/com/beyond/MKX/domain/brokerage/dto/LedgerDTO.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/brokerage/dto/LedgerDTO.java
@@ -1,0 +1,38 @@
+package com.beyond.MKX.domain.brokerage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 증권사 대시보드용 거래내역 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LedgerDTO {
+    private UUID id;
+    private UUID orderLogId;
+    private String ticker;
+    private String stockName;
+    private String transactionType; // BUY, SELL, DEPOSIT, WITHDRAWAL 등
+    private String transactionTypeKorean;
+    private Long quantity;
+    private Long price;
+    private Long totalAmount;
+    private Long debit;
+    private Long credit;
+    private Long commission;
+    private Long tax;
+    private String accountNumber;
+    private String memberName;
+    private String counterpartyAccountNumber;
+    private String counterpartyName;
+    private LocalDateTime createdAt;
+}
+

--- a/ordering/src/main/java/com/beyond/MKX/domain/brokerage/dto/OrderLogDTO.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/brokerage/dto/OrderLogDTO.java
@@ -1,0 +1,36 @@
+package com.beyond.MKX.domain.brokerage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 증권사 대시보드용 주문 내역 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderLogDTO {
+    private UUID id;
+    private String ticker;
+    private String stockName;
+    private String orderKind; // MARKET, LIMIT, RESERVED
+    private String side; // BUY, SELL
+    private String status; // PENDING, FILLED, CANCELED 등
+    private Long price;
+    private Long quantity;
+    private Long remainQuantity;
+    private Long commission;
+    private Long transactionTax;
+    private String accountNumber;
+    private String memberName;
+    private LocalDateTime createdAt;
+    private LocalDateTime filledAt;
+    private LocalDateTime canceledAt;
+}
+

--- a/ordering/src/main/java/com/beyond/MKX/domain/brokerage/dto/PopularStockDTO.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/brokerage/dto/PopularStockDTO.java
@@ -1,0 +1,20 @@
+package com.beyond.MKX.domain.brokerage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 증권사별 인기 종목 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PopularStockDTO {
+    private String ticker;
+    private String stockName; // 종목명 (한글)
+    private Long customerCount; // 보유 고객 수 (distinct memberAccountId 개수)
+    private Long totalQuantity; // 총 보유량 (totalQuantity 합계)
+}

--- a/ordering/src/main/java/com/beyond/MKX/domain/brokerage/dto/RecentActivityDTO.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/brokerage/dto/RecentActivityDTO.java
@@ -1,0 +1,32 @@
+package com.beyond.MKX.domain.brokerage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 증권사 대시보드용 최근 활동 DTO
+ * - order_log와 ledger를 통합하여 최근 활동 목록을 제공
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecentActivityDTO {
+    private UUID id;
+    private String type; // "ORDER" 또는 "LEDGER"
+    private String activityType; // 주문/거래 유형
+    private String activityTypeKorean; // 주문/거래 유형 한글명
+    private String ticker; // 종목 티커
+    private String stockName; // 종목명
+    private Long quantity; // 수량
+    private Long amount; // 금액
+    private String accountNumber; // 계좌번호
+    private String memberName; // 회원명
+    private LocalDateTime createdAt; // 생성 일시
+}
+

--- a/ordering/src/main/java/com/beyond/MKX/domain/brokerage/service/BrokerageDashboardService.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/brokerage/service/BrokerageDashboardService.java
@@ -1,0 +1,484 @@
+package com.beyond.MKX.domain.brokerage.service;
+
+import com.beyond.MKX.domain.account.member.client.MemberInternalClient;
+import com.beyond.MKX.domain.assets.dto.StockInfoResDTO;
+import com.beyond.MKX.domain.assets.entity.AccountStatus;
+import com.beyond.MKX.domain.assets.entity.MemberAccount;
+import com.beyond.MKX.domain.assets.entity.StockHolding;
+import com.beyond.MKX.domain.assets.repository.MemberAccountRepository;
+import com.beyond.MKX.domain.assets.repository.StockHoldingRepository;
+import com.beyond.MKX.domain.assets.service.StockFeign;
+import com.beyond.MKX.domain.brokerage.dto.BrokerageStatsDTO;
+import com.beyond.MKX.domain.brokerage.dto.LedgerDTO;
+import com.beyond.MKX.domain.brokerage.dto.OrderLogDTO;
+import com.beyond.MKX.domain.brokerage.dto.PopularStockDTO;
+import com.beyond.MKX.domain.brokerage.dto.RecentActivityDTO;
+import com.beyond.MKX.domain.execution.entity.Ledger;
+import com.beyond.MKX.domain.execution.entity.TransactionType;
+import com.beyond.MKX.domain.execution.repository.LedgerRepository;
+import com.beyond.MKX.domain.order.entity.OrderLog;
+import com.beyond.MKX.domain.order.entity.OrderStatus;
+import com.beyond.MKX.domain.order.entity.Side;
+import com.beyond.MKX.domain.order.repository.OrderLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BrokerageDashboardService {
+
+    private final OrderLogRepository orderLogRepository;
+    private final LedgerRepository ledgerRepository;
+    private final MemberAccountRepository memberAccountRepository;
+    private final StockHoldingRepository stockHoldingRepository;
+    private final StockFeign stockFeign;
+    private final MemberInternalClient memberInternalClient;
+
+    /**
+     * 증권사별 최근 활동 목록 조회 (order_log + ledger 통합)
+     * - 최근 생성일시 기준으로 정렬하여 반환
+     */
+    @Transactional(readOnly = true)
+    public List<RecentActivityDTO> getRecentActivities(UUID brokerageId, int limit) {
+        Pageable pageable = PageRequest.of(0, limit * 2, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        // 1. order_log 조회
+        Page<OrderLog> orderLogs = orderLogRepository.findByBrokerageIdOrderByCreatedAtDesc(brokerageId, pageable);
+        List<RecentActivityDTO> activities = new ArrayList<>();
+
+        for (OrderLog orderLog : orderLogs.getContent()) {
+            try {
+                MemberAccount account = orderLog.getAccount();
+                String accountNumber = account != null ? account.getNumber() : "N/A";
+                String memberName = getMemberName(account);
+
+                String stockName = getStockName(orderLog.getTicker());
+
+                RecentActivityDTO activity = RecentActivityDTO.builder()
+                    .id(orderLog.getId())
+                    .type("ORDER")
+                    .activityType(orderLog.getSide().name())
+                    .activityTypeKorean(getOrderActivityTypeKorean(orderLog.getSide(), orderLog.getStatus()))
+                    .ticker(orderLog.getTicker())
+                    .stockName(stockName)
+                    .quantity(orderLog.getQuantity())
+                    .amount(orderLog.getPrice() != null ? orderLog.getPrice() * orderLog.getQuantity() : 0L)
+                    .accountNumber(accountNumber)
+                    .memberName(memberName)
+                    .createdAt(orderLog.getCreatedAt())
+                    .build();
+                activities.add(activity);
+            } catch (Exception e) {
+                log.warn("Failed to process order log {}: {}", orderLog.getId(), e.getMessage());
+            }
+        }
+
+        // 2. ledger 조회
+        Page<Ledger> ledgers = ledgerRepository.findByBrokerageIdOrderByCreatedAtDesc(brokerageId, pageable);
+        for (Ledger ledger : ledgers.getContent()) {
+            try {
+                // ledger의 creditAccountId 또는 debitAccountId가 증권사 계좌가 아닌 회원 계좌인 경우 조회
+                UUID memberAccountId = null;
+                if (ledger.getCreditAccountId() != null && !ledger.getCreditAccountId().equals(brokerageId)) {
+                    memberAccountId = ledger.getCreditAccountId();
+                } else if (ledger.getDebitAccountId() != null && !ledger.getDebitAccountId().equals(brokerageId)) {
+                    memberAccountId = ledger.getDebitAccountId();
+                }
+                
+                final String[] accountNumber = {"N/A"};
+                final String[] memberName = {"N/A"};
+                
+                if (memberAccountId != null) {
+                    memberAccountRepository.findById(memberAccountId)
+                        .ifPresent(account -> {
+                            accountNumber[0] = account.getNumber();
+                            memberName[0] = getMemberName(account);
+                        });
+                }
+
+                String stockName = ledger.getTicker() != null ? getStockName(ledger.getTicker()) : "N/A";
+
+                RecentActivityDTO activity = RecentActivityDTO.builder()
+                    .id(ledger.getId())
+                    .type("LEDGER")
+                    .activityType(ledger.getTransactionType() != null ? ledger.getTransactionType().name() : "UNKNOWN")
+                    .activityTypeKorean(getTransactionTypeKorean(ledger.getTransactionType()))
+                    .ticker(ledger.getTicker())
+                    .stockName(stockName)
+                    .quantity(ledger.getQtyChange())
+                    .amount(ledger.getCredit() != null ? ledger.getCredit() : ledger.getDebit())
+                    .accountNumber(accountNumber[0])
+                    .memberName(memberName[0])
+                    .createdAt(ledger.getCreatedAt())
+                    .build();
+                activities.add(activity);
+            } catch (Exception e) {
+                log.warn("Failed to process ledger {}: {}", ledger.getId(), e.getMessage());
+            }
+        }
+
+        // 3. 생성일시 기준으로 정렬하고 limit만큼 반환
+        return activities.stream()
+            .sorted(Comparator.comparing(RecentActivityDTO::getCreatedAt).reversed())
+            .limit(limit)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * 증권사별 주문 내역 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<OrderLogDTO> getOrderLogs(UUID brokerageId, Pageable pageable) {
+        Page<OrderLog> orderLogs = orderLogRepository.findByBrokerageIdOrderByCreatedAtDesc(brokerageId, pageable);
+
+        return orderLogs.map(orderLog -> {
+            try {
+                MemberAccount account = orderLog.getAccount();
+                String accountNumber = account != null ? account.getNumber() : "N/A";
+                String memberName = getMemberName(account);
+                String stockName = getStockName(orderLog.getTicker());
+
+                return OrderLogDTO.builder()
+                    .id(orderLog.getId())
+                    .ticker(orderLog.getTicker())
+                    .stockName(stockName)
+                    .orderKind(orderLog.getOrderKind().name())
+                    .side(orderLog.getSide().name())
+                    .status(orderLog.getStatus().name())
+                    .price(orderLog.getPrice())
+                    .quantity(orderLog.getQuantity())
+                    .remainQuantity(orderLog.getRemainQuantity())
+                    .commission(orderLog.getCommission())
+                    .transactionTax(orderLog.getTransactionTax())
+                    .accountNumber(accountNumber)
+                    .memberName(memberName)
+                    .createdAt(orderLog.getCreatedAt())
+                    .filledAt(orderLog.getFilledAt())
+                    .canceledAt(orderLog.getCanceledAt())
+                    .build();
+            } catch (Exception e) {
+                log.warn("Failed to convert order log {}: {}", orderLog.getId(), e.getMessage());
+                return OrderLogDTO.builder()
+                    .id(orderLog.getId())
+                    .ticker(orderLog.getTicker())
+                    .stockName("N/A")
+                    .orderKind(orderLog.getOrderKind().name())
+                    .side(orderLog.getSide().name())
+                    .status(orderLog.getStatus().name())
+                    .price(orderLog.getPrice())
+                    .quantity(orderLog.getQuantity())
+                    .remainQuantity(orderLog.getRemainQuantity())
+                    .commission(orderLog.getCommission())
+                    .transactionTax(orderLog.getTransactionTax())
+                    .accountNumber("N/A")
+                    .memberName("N/A")
+                    .createdAt(orderLog.getCreatedAt())
+                    .filledAt(orderLog.getFilledAt())
+                    .canceledAt(orderLog.getCanceledAt())
+                    .build();
+            }
+        });
+    }
+
+    /**
+     * 증권사별 통계 조회 (총 고객 수, 활성 계좌 수, 일일 거래량, 월간 수익, 변화율)
+     */
+    @Transactional(readOnly = true)
+    public BrokerageStatsDTO getBrokerageStats(UUID brokerageId) {
+        // 1. 총 고객 수 및 활성 계좌 수 조회
+        List<MemberAccount> allAccounts = memberAccountRepository.findAllByBrokerageId(brokerageId);
+        long totalCustomers = allAccounts.stream()
+            .map(MemberAccount::getMemberId)
+            .distinct()
+            .count();
+        
+        long activeAccounts = allAccounts.stream()
+            .filter(acc -> acc.getStatus() == AccountStatus.ACTIVE)
+            .count();
+        
+        // TODO: 실제 온라인 고객 수 추적 필요 (현재는 활성 계좌 수로 대체)
+        long onlineCustomers = activeAccounts;
+        
+        // 2. 일일 거래량 (오늘)
+        LocalDate today = LocalDate.now();
+        LocalDateTime todayStart = today.atStartOfDay();
+        LocalDateTime todayEnd = today.atTime(LocalTime.MAX);
+        
+        Long dailyVolume = ledgerRepository.getDailyVolumeByBrokerageId(brokerageId, todayStart, todayEnd);
+        if (dailyVolume == null) {
+            dailyVolume = 0L;
+        }
+        
+        // 3. 전일 거래량 (어제)
+        LocalDate yesterday = today.minusDays(1);
+        LocalDateTime yesterdayStart = yesterday.atStartOfDay();
+        LocalDateTime yesterdayEnd = yesterday.atTime(LocalTime.MAX);
+        
+        Long yesterdayVolume = ledgerRepository.getDailyVolumeByBrokerageId(brokerageId, yesterdayStart, yesterdayEnd);
+        if (yesterdayVolume == null || yesterdayVolume == 0) {
+            yesterdayVolume = 1L; // 0으로 나누기 방지
+        }
+        
+        // 4. 거래량 변화율 계산
+        double volumeChangePercent = 0.0;
+        if (yesterdayVolume > 1L) {
+            volumeChangePercent = ((double)(dailyVolume - yesterdayVolume) / yesterdayVolume) * 100.0;
+        } else if (dailyVolume > 0) {
+            volumeChangePercent = 100.0; // 전일 거래가 없었는데 오늘 거래가 있으면 100% 증가
+        }
+        
+        // 5. 월간 수익 (이번 달)
+        // 매수(BUY): debitAccountId = brokerageId인 ledger의 commission (증권사가 출금하는 쪽이므로 수수료를 받음)
+        // 매도(SELL): creditAccountId = brokerageId인 ledger의 commission (증권사가 입금받는 쪽이므로 수수료를 받음)
+        int currentYear = today.getYear();
+        int currentMonth = today.getMonthValue();
+        
+        // 매수 수수료: transactionType이 BUY이고 brokerageId와 관련된 거래의 commission
+        Long buyCommission = ledgerRepository.getBuyCommissionByBrokerageId(
+            brokerageId, TransactionType.BUY, currentYear, currentMonth);
+        if (buyCommission == null) {
+            buyCommission = 0L;
+        }
+        
+        // 매도 수수료: transactionType이 SELL이고 brokerageId와 관련된 거래의 commission
+        Long sellCommission = ledgerRepository.getSellCommissionByBrokerageId(
+            brokerageId, TransactionType.SELL, currentYear, currentMonth);
+        if (sellCommission == null) {
+            sellCommission = 0L;
+        }
+        
+        Long monthlyRevenue = buyCommission + sellCommission;
+        
+        // 6. 전월 수익
+        LocalDate lastMonthDate = today.minusMonths(1);
+        int lastMonthYear = lastMonthDate.getYear();
+        int lastMonth = lastMonthDate.getMonthValue();
+        
+        Long lastMonthBuyCommission = ledgerRepository.getBuyCommissionByBrokerageId(
+            brokerageId, TransactionType.BUY, lastMonthYear, lastMonth);
+        if (lastMonthBuyCommission == null) {
+            lastMonthBuyCommission = 0L;
+        }
+        
+        Long lastMonthSellCommission = ledgerRepository.getSellCommissionByBrokerageId(
+            brokerageId, TransactionType.SELL, lastMonthYear, lastMonth);
+        if (lastMonthSellCommission == null) {
+            lastMonthSellCommission = 0L;
+        }
+        
+        Long lastMonthRevenue = lastMonthBuyCommission + lastMonthSellCommission;
+        if (lastMonthRevenue == 0) {
+            lastMonthRevenue = 1L; // 0으로 나누기 방지
+        }
+        
+        // 7. 수익 변화율 계산
+        double revenueChangePercent = 0.0;
+        if (lastMonthRevenue > 1L) {
+            revenueChangePercent = ((double)(monthlyRevenue - lastMonthRevenue) / lastMonthRevenue) * 100.0;
+        } else if (monthlyRevenue > 0) {
+            revenueChangePercent = 100.0; // 전월 수익이 없었는데 이번 달 수익이 있으면 100% 증가
+        }
+        
+        return BrokerageStatsDTO.builder()
+            .totalCustomers(totalCustomers)
+            .activeAccounts(activeAccounts)
+            .onlineCustomers(onlineCustomers)
+            .dailyVolume(dailyVolume)
+            .monthlyRevenue(monthlyRevenue)
+            .buyCommission(buyCommission)
+            .sellCommission(sellCommission)
+            .volumeChangePercent(volumeChangePercent)
+            .revenueChangePercent(revenueChangePercent)
+            .build();
+    }
+
+    /**
+     * 증권사별 인기 종목 조회 (보유 고객 수 기준 TOP 10)
+     */
+    @Transactional(readOnly = true)
+    public List<PopularStockDTO> getPopularStocks(UUID brokerageId, int limit) {
+        // 1. 해당 증권사의 모든 stock_holding 조회
+        List<StockHolding> holdings = stockHoldingRepository.findAllByBrokerageId(brokerageId);
+        
+        // 2. ticker별로 그룹화하여 집계
+        Map<String, List<StockHolding>> holdingsByTicker = holdings.stream()
+            .filter(h -> h.getTotalQuantity() > 0) // 보유 수량이 0보다 큰 것만
+            .collect(Collectors.groupingBy(StockHolding::getTicker));
+        
+        // 3. 각 ticker별로 PopularStockDTO 생성
+        List<PopularStockDTO> popularStocks = new ArrayList<>();
+        for (Map.Entry<String, List<StockHolding>> entry : holdingsByTicker.entrySet()) {
+            String ticker = entry.getKey();
+            List<StockHolding> tickerHoldings = entry.getValue();
+            
+            // 보유 고객 수 = distinct memberAccountId 개수
+            long customerCount = tickerHoldings.stream()
+                .map(StockHolding::getMemberAccountId)
+                .distinct()
+                .count();
+            
+            // 총 보유량 = totalQuantity 합계
+            long totalQuantity = tickerHoldings.stream()
+                .mapToLong(StockHolding::getTotalQuantity)
+                .sum();
+            
+            // 종목명 조회
+            String stockName = getStockName(ticker);
+            
+            popularStocks.add(PopularStockDTO.builder()
+                .ticker(ticker)
+                .stockName(stockName)
+                .customerCount(customerCount)
+                .totalQuantity(totalQuantity)
+                .build());
+        }
+        
+        // 4. 보유 고객 수 기준으로 정렬하고 limit만큼 반환
+        return popularStocks.stream()
+            .sorted(Comparator.comparing(PopularStockDTO::getCustomerCount).reversed())
+            .limit(limit)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * 증권사별 거래내역 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<LedgerDTO> getLedgers(UUID brokerageId, Pageable pageable) {
+        Page<Ledger> ledgers = ledgerRepository.findByBrokerageIdOrderByCreatedAtDesc(brokerageId, pageable);
+
+        return ledgers.map(ledger -> {
+            try {
+                UUID memberAccountId = null;
+                if (ledger.getCreditAccountId() != null && !ledger.getCreditAccountId().equals(brokerageId)) {
+                    memberAccountId = ledger.getCreditAccountId();
+                } else if (ledger.getDebitAccountId() != null && !ledger.getDebitAccountId().equals(brokerageId)) {
+                    memberAccountId = ledger.getDebitAccountId();
+                }
+                
+                final String[] accountNumber = {"N/A"};
+                final String[] memberName = {"N/A"};
+                
+                if (memberAccountId != null) {
+                    memberAccountRepository.findById(memberAccountId)
+                        .ifPresent(account -> {
+                            accountNumber[0] = account.getNumber();
+                            memberName[0] = getMemberName(account);
+                        });
+                }
+
+                String stockName = ledger.getTicker() != null ? getStockName(ledger.getTicker()) : "N/A";
+
+                return LedgerDTO.builder()
+                    .id(ledger.getId())
+                    .orderLogId(ledger.getOrderLogId())
+                    .ticker(ledger.getTicker())
+                    .stockName(stockName)
+                    .transactionType(ledger.getTransactionType() != null ? ledger.getTransactionType().name() : "UNKNOWN")
+                    .transactionTypeKorean(getTransactionTypeKorean(ledger.getTransactionType()))
+                    .quantity(ledger.getQtyChange())
+                    .price(ledger.getAmountChange())
+                    .totalAmount(ledger.getCredit() != null ? ledger.getCredit() : ledger.getDebit())
+                    .debit(ledger.getDebit())
+                    .credit(ledger.getCredit())
+                    .commission(ledger.getCommission())
+                    .tax(ledger.getTax())
+                    .accountNumber(accountNumber[0])
+                    .memberName(memberName[0])
+                    .counterpartyAccountNumber(ledger.getCounterpartyAccountNumber())
+                    .counterpartyName(ledger.getCounterpartyName())
+                    .createdAt(ledger.getCreatedAt())
+                    .build();
+            } catch (Exception e) {
+                log.warn("Failed to convert ledger {}: {}", ledger.getId(), e.getMessage());
+                return LedgerDTO.builder()
+                    .id(ledger.getId())
+                    .orderLogId(ledger.getOrderLogId())
+                    .ticker(ledger.getTicker())
+                    .stockName("N/A")
+                    .transactionType(ledger.getTransactionType() != null ? ledger.getTransactionType().name() : "UNKNOWN")
+                    .transactionTypeKorean(getTransactionTypeKorean(ledger.getTransactionType()))
+                    .quantity(ledger.getQtyChange())
+                    .price(ledger.getAmountChange())
+                    .totalAmount(ledger.getCredit() != null ? ledger.getCredit() : ledger.getDebit())
+                    .debit(ledger.getDebit())
+                    .credit(ledger.getCredit())
+                    .commission(ledger.getCommission())
+                    .tax(ledger.getTax())
+                    .accountNumber("N/A")
+                    .memberName("N/A")
+                    .counterpartyAccountNumber(ledger.getCounterpartyAccountNumber())
+                    .counterpartyName(ledger.getCounterpartyName())
+                    .createdAt(ledger.getCreatedAt())
+                    .build();
+            }
+        });
+    }
+
+    private String getMemberName(MemberAccount account) {
+        if (account == null || account.getMemberId() == null) {
+            return "N/A";
+        }
+        try {
+            Map<String, String> nameResponse = memberInternalClient.getMemberName(account.getMemberId());
+            return nameResponse != null && nameResponse.containsKey("name") 
+                ? nameResponse.get("name") 
+                : "회원 " + account.getNumber().substring(Math.max(0, account.getNumber().length() - 4));
+        } catch (Exception e) {
+            log.warn("Failed to get member name for account {}: {}", account.getId(), e.getMessage());
+            return "회원 " + account.getNumber().substring(Math.max(0, account.getNumber().length() - 4));
+        }
+    }
+
+    private String getStockName(String ticker) {
+        if (ticker == null || ticker.isEmpty()) {
+            return "N/A";
+        }
+        try {
+            StockInfoResDTO stockInfo = stockFeign.getStockByTicker(ticker);
+            return stockInfo != null ? stockInfo.getNameKo() : ticker;
+        } catch (Exception e) {
+            log.warn("Failed to get stock name for ticker {}: {}", ticker, e.getMessage());
+            return ticker;
+        }
+    }
+
+    private String getOrderActivityTypeKorean(Side side, OrderStatus status) {
+        if (status == OrderStatus.CANCELED) {
+            return "주문 취소";
+        }
+        return side == Side.BUY ? "매수 주문" : "매도 주문";
+    }
+
+    private String getTransactionTypeKorean(TransactionType type) {
+        if (type == null) {
+            return "알 수 없음";
+        }
+        return switch (type) {
+            case BUY -> "매수";
+            case SELL -> "매도";
+            case DEPOSIT -> "입금";
+            case WITHDRAWAL -> "출금";
+            case DELISTING_REFUND -> "상장폐지 환불";
+            default -> type.name();
+        };
+    }
+}
+

--- a/ordering/src/main/java/com/beyond/MKX/domain/brokerage/service/BrokerageDashboardService.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/brokerage/service/BrokerageDashboardService.java
@@ -244,56 +244,52 @@ public class BrokerageDashboardService {
             volumeChangePercent = 100.0; // 전일 거래가 없었는데 오늘 거래가 있으면 100% 증가
         }
         
-        // 5. 월간 수익 (이번 달)
-        // 매수(BUY): debitAccountId = brokerageId인 ledger의 commission (증권사가 출금하는 쪽이므로 수수료를 받음)
-        // 매도(SELL): creditAccountId = brokerageId인 ledger의 commission (증권사가 입금받는 쪽이므로 수수료를 받음)
-        int currentYear = today.getYear();
-        int currentMonth = today.getMonthValue();
+        // 5. 월간 수익 (최근 30일)
+        // 매수(BUY)와 매도(SELL) 거래의 수수료를 합산하여 월간 수익 계산
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime thirtyDaysAgo = now.minusDays(30);
+        LocalDateTime sixtyDaysAgo = now.minusDays(60);
         
-        // 매수 수수료: transactionType이 BUY이고 brokerageId와 관련된 거래의 commission
-        Long buyCommission = ledgerRepository.getBuyCommissionByBrokerageId(
-            brokerageId, TransactionType.BUY, currentYear, currentMonth);
+        // 최근 30일 매수 수수료
+        Long buyCommission = ledgerRepository.getCommissionByBrokerageIdAndDateRange(
+            brokerageId, TransactionType.BUY, thirtyDaysAgo, now);
         if (buyCommission == null) {
             buyCommission = 0L;
         }
         
-        // 매도 수수료: transactionType이 SELL이고 brokerageId와 관련된 거래의 commission
-        Long sellCommission = ledgerRepository.getSellCommissionByBrokerageId(
-            brokerageId, TransactionType.SELL, currentYear, currentMonth);
+        // 최근 30일 매도 수수료
+        Long sellCommission = ledgerRepository.getCommissionByBrokerageIdAndDateRange(
+            brokerageId, TransactionType.SELL, thirtyDaysAgo, now);
         if (sellCommission == null) {
             sellCommission = 0L;
         }
         
         Long monthlyRevenue = buyCommission + sellCommission;
         
-        // 6. 전월 수익
-        LocalDate lastMonthDate = today.minusMonths(1);
-        int lastMonthYear = lastMonthDate.getYear();
-        int lastMonth = lastMonthDate.getMonthValue();
-        
-        Long lastMonthBuyCommission = ledgerRepository.getBuyCommissionByBrokerageId(
-            brokerageId, TransactionType.BUY, lastMonthYear, lastMonth);
-        if (lastMonthBuyCommission == null) {
-            lastMonthBuyCommission = 0L;
+        // 6. 이전 30일 수익 (30일 전 ~ 60일 전)
+        Long previousBuyCommission = ledgerRepository.getCommissionByBrokerageIdAndDateRange(
+            brokerageId, TransactionType.BUY, sixtyDaysAgo, thirtyDaysAgo);
+        if (previousBuyCommission == null) {
+            previousBuyCommission = 0L;
         }
         
-        Long lastMonthSellCommission = ledgerRepository.getSellCommissionByBrokerageId(
-            brokerageId, TransactionType.SELL, lastMonthYear, lastMonth);
-        if (lastMonthSellCommission == null) {
-            lastMonthSellCommission = 0L;
+        Long previousSellCommission = ledgerRepository.getCommissionByBrokerageIdAndDateRange(
+            brokerageId, TransactionType.SELL, sixtyDaysAgo, thirtyDaysAgo);
+        if (previousSellCommission == null) {
+            previousSellCommission = 0L;
         }
         
-        Long lastMonthRevenue = lastMonthBuyCommission + lastMonthSellCommission;
-        if (lastMonthRevenue == 0) {
-            lastMonthRevenue = 1L; // 0으로 나누기 방지
+        Long previousRevenue = previousBuyCommission + previousSellCommission;
+        if (previousRevenue == 0) {
+            previousRevenue = 1L; // 0으로 나누기 방지
         }
         
         // 7. 수익 변화율 계산
         double revenueChangePercent = 0.0;
-        if (lastMonthRevenue > 1L) {
-            revenueChangePercent = ((double)(monthlyRevenue - lastMonthRevenue) / lastMonthRevenue) * 100.0;
+        if (previousRevenue > 1L) {
+            revenueChangePercent = ((double)(monthlyRevenue - previousRevenue) / previousRevenue) * 100.0;
         } else if (monthlyRevenue > 0) {
-            revenueChangePercent = 100.0; // 전월 수익이 없었는데 이번 달 수익이 있으면 100% 증가
+            revenueChangePercent = 100.0; // 이전 30일 수익이 없었는데 최근 30일 수익이 있으면 100% 증가
         }
         
         return BrokerageStatsDTO.builder()

--- a/ordering/src/main/java/com/beyond/MKX/domain/brokerage/service/BrokerageDashboardService.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/brokerage/service/BrokerageDashboardService.java
@@ -297,6 +297,26 @@ public class BrokerageDashboardService {
             revenueChangePercent = 100.0; // 이전 30일 수익이 없었는데 최근 30일 수익이 있으면 100% 증가
         }
         
+        // 8. 7일 전 데이터와 비교하여 변화량 계산
+        LocalDateTime sevenDaysAgo = now.minusDays(7);
+        
+        // 7일 전 기준 총 고객 수 (7일 전 이전에 생성된 계좌만)
+        long sevenDaysAgoTotalCustomers = allAccounts.stream()
+            .filter(acc -> acc.getCreatedAt() != null && acc.getCreatedAt().isBefore(sevenDaysAgo))
+            .map(MemberAccount::getMemberId)
+            .distinct()
+            .count();
+        
+        // 7일 전 기준 활성 계좌 수 (7일 전 이전에 생성되고 현재도 활성 상태인 계좌)
+        long sevenDaysAgoActiveAccounts = allAccounts.stream()
+            .filter(acc -> acc.getCreatedAt() != null && acc.getCreatedAt().isBefore(sevenDaysAgo))
+            .filter(acc -> acc.getStatus() == AccountStatus.ACTIVE)
+            .count();
+        
+        // 변화량 계산 (현재 - 7일 전)
+        long customerChange = totalCustomers - sevenDaysAgoTotalCustomers;
+        long accountChange = activeAccounts - sevenDaysAgoActiveAccounts;
+        
         return BrokerageStatsDTO.builder()
             .totalCustomers(totalCustomers)
             .activeAccounts(activeAccounts)
@@ -307,6 +327,8 @@ public class BrokerageDashboardService {
             .sellCommission(sellCommission)
             .volumeChangePercent(volumeChangePercent)
             .revenueChangePercent(revenueChangePercent)
+            .customerChange(customerChange)
+            .accountChange(accountChange)
             .build();
     }
 

--- a/ordering/src/main/java/com/beyond/MKX/domain/brokerage/service/BrokerageDashboardService.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/brokerage/service/BrokerageDashboardService.java
@@ -213,20 +213,25 @@ public class BrokerageDashboardService {
             .filter(acc -> acc.getStatus() == AccountStatus.ACTIVE)
             .count();
         
-        // TODO: 실제 온라인 고객 수 추적 필요 (현재는 활성 계좌 수로 대체)
-        long onlineCustomers = activeAccounts;
-        
-        // 2. 일일 거래량 (오늘)
+        // 3. 오늘 주문한 고객 수 (오늘 00:00 ~ 23:59:59 안에 주문을 넣은 회원 계좌 수)
         LocalDate today = LocalDate.now();
         LocalDateTime todayStart = today.atStartOfDay();
-        LocalDateTime todayEnd = today.atTime(LocalTime.MAX);
+        LocalDateTime todayEnd = today.atTime(LocalTime.MAX).plusSeconds(1); // 23:59:59까지 포함
         
-        Long dailyVolume = ledgerRepository.getDailyVolumeByBrokerageId(brokerageId, todayStart, todayEnd);
+        Long onlineCustomersCount = orderLogRepository.countDistinctMemberAccountsByBrokerageIdAndDateRange(
+            brokerageId, todayStart, todayEnd);
+        long onlineCustomers = onlineCustomersCount != null ? onlineCustomersCount : 0L;
+        
+        // 4. 일일 거래량 (오늘)
+        LocalDateTime todayVolumeStart = today.atStartOfDay();
+        LocalDateTime todayVolumeEnd = today.atTime(LocalTime.MAX);
+        
+        Long dailyVolume = ledgerRepository.getDailyVolumeByBrokerageId(brokerageId, todayVolumeStart, todayVolumeEnd);
         if (dailyVolume == null) {
             dailyVolume = 0L;
         }
         
-        // 3. 전일 거래량 (어제)
+        // 5. 전일 거래량 (어제)
         LocalDate yesterday = today.minusDays(1);
         LocalDateTime yesterdayStart = yesterday.atStartOfDay();
         LocalDateTime yesterdayEnd = yesterday.atTime(LocalTime.MAX);
@@ -236,7 +241,7 @@ public class BrokerageDashboardService {
             yesterdayVolume = 1L; // 0으로 나누기 방지
         }
         
-        // 4. 거래량 변화율 계산
+        // 6. 거래량 변화율 계산
         double volumeChangePercent = 0.0;
         if (yesterdayVolume > 1L) {
             volumeChangePercent = ((double)(dailyVolume - yesterdayVolume) / yesterdayVolume) * 100.0;

--- a/ordering/src/main/java/com/beyond/MKX/domain/execution/repository/LedgerRepository.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/execution/repository/LedgerRepository.java
@@ -62,4 +62,5 @@ public interface LedgerRepository extends JpaRepository<Ledger, UUID> {
                                                  @Param("transactionType") TransactionType transactionType,
                                                  @Param("startDateTime") java.time.LocalDateTime startDateTime,
                                                  @Param("endDateTime") java.time.LocalDateTime endDateTime);
+
 }

--- a/ordering/src/main/java/com/beyond/MKX/domain/execution/repository/LedgerRepository.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/execution/repository/LedgerRepository.java
@@ -44,40 +44,22 @@ public interface LedgerRepository extends JpaRepository<Ledger, UUID> {
                                       @Param("endDateTime") java.time.LocalDateTime endDateTime);
 
     /**
-     * 증권사별 월간 수익 조회 (매수 수수료)
+     * 증권사별 수익 조회 (매수 수수료) - 날짜 범위 기준
      * transactionType이 BUY이고 creditAccountId 또는 debitAccountId가 brokerageId와 일치하는 ledger의 commission 합계
      * 
      * @param brokerageId 증권사 ID
-     * @param year 년도
-     * @param month 월
+     * @param transactionType 거래 유형
+     * @param startDateTime 시작 일시
+     * @param endDateTime 종료 일시
      * @return 매수 수수료 합계
      */
     @Query("SELECT COALESCE(SUM(l.commission), 0) FROM Ledger l " +
            "WHERE l.transactionType = :transactionType " +
            "AND (l.creditAccountId = :brokerageId OR l.debitAccountId = :brokerageId) " +
            "AND l.commission IS NOT NULL AND l.commission > 0 " +
-           "AND YEAR(l.createdAt) = :year AND MONTH(l.createdAt) = :month")
-    Long getBuyCommissionByBrokerageId(@Param("brokerageId") UUID brokerageId,
-                                        @Param("transactionType") TransactionType transactionType,
-                                        @Param("year") int year,
-                                        @Param("month") int month);
-
-    /**
-     * 증권사별 월간 수익 조회 (매도 수수료)
-     * transactionType이 SELL이고 creditAccountId 또는 debitAccountId가 brokerageId와 일치하는 ledger의 commission 합계
-     * 
-     * @param brokerageId 증권사 ID
-     * @param year 년도
-     * @param month 월
-     * @return 매도 수수료 합계
-     */
-    @Query("SELECT COALESCE(SUM(l.commission), 0) FROM Ledger l " +
-           "WHERE l.transactionType = :transactionType " +
-           "AND (l.creditAccountId = :brokerageId OR l.debitAccountId = :brokerageId) " +
-           "AND l.commission IS NOT NULL AND l.commission > 0 " +
-           "AND YEAR(l.createdAt) = :year AND MONTH(l.createdAt) = :month")
-    Long getSellCommissionByBrokerageId(@Param("brokerageId") UUID brokerageId,
-                                         @Param("transactionType") TransactionType transactionType,
-                                         @Param("year") int year,
-                                         @Param("month") int month);
+           "AND l.createdAt >= :startDateTime AND l.createdAt < :endDateTime")
+    Long getCommissionByBrokerageIdAndDateRange(@Param("brokerageId") UUID brokerageId,
+                                                 @Param("transactionType") TransactionType transactionType,
+                                                 @Param("startDateTime") java.time.LocalDateTime startDateTime,
+                                                 @Param("endDateTime") java.time.LocalDateTime endDateTime);
 }

--- a/ordering/src/main/java/com/beyond/MKX/domain/execution/repository/LedgerRepository.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/execution/repository/LedgerRepository.java
@@ -5,6 +5,8 @@ import com.beyond.MKX.domain.execution.entity.TransactionType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.UUID;
 
@@ -22,4 +24,60 @@ public interface LedgerRepository extends JpaRepository<Ledger, UUID> {
      */
     Page<Ledger> findByCreditAccountIdOrDebitAccountIdAndTransactionTypeOrderByCreatedAtDesc(
         UUID creditAccountId, UUID debitAccountId, TransactionType transactionType, Pageable pageable);
+    
+    /**
+     * 증권사별 최근 거래내역 조회
+     * creditAccountId 또는 debitAccountId가 증권사 ID와 일치하는 레코드를 조회합니다.
+     */
+    @Query("SELECT l FROM Ledger l WHERE l.creditAccountId = :brokerageId OR l.debitAccountId = :brokerageId ORDER BY l.createdAt DESC")
+    Page<Ledger> findByBrokerageIdOrderByCreatedAtDesc(@Param("brokerageId") UUID brokerageId, Pageable pageable);
+
+    /**
+     * 증권사별 일일 거래량 조회 (특정 날짜 범위)
+     * credit 또는 debit 중 큰 값을 합산하여 거래량 계산
+     */
+    @Query("SELECT COALESCE(SUM(GREATEST(COALESCE(l.credit, 0), COALESCE(l.debit, 0))), 0) FROM Ledger l " +
+           "WHERE (l.creditAccountId = :brokerageId OR l.debitAccountId = :brokerageId) " +
+           "AND l.createdAt >= :startDateTime AND l.createdAt < :endDateTime")
+    Long getDailyVolumeByBrokerageId(@Param("brokerageId") UUID brokerageId, 
+                                      @Param("startDateTime") java.time.LocalDateTime startDateTime,
+                                      @Param("endDateTime") java.time.LocalDateTime endDateTime);
+
+    /**
+     * 증권사별 월간 수익 조회 (매수 수수료)
+     * transactionType이 BUY이고 creditAccountId 또는 debitAccountId가 brokerageId와 일치하는 ledger의 commission 합계
+     * 
+     * @param brokerageId 증권사 ID
+     * @param year 년도
+     * @param month 월
+     * @return 매수 수수료 합계
+     */
+    @Query("SELECT COALESCE(SUM(l.commission), 0) FROM Ledger l " +
+           "WHERE l.transactionType = :transactionType " +
+           "AND (l.creditAccountId = :brokerageId OR l.debitAccountId = :brokerageId) " +
+           "AND l.commission IS NOT NULL AND l.commission > 0 " +
+           "AND YEAR(l.createdAt) = :year AND MONTH(l.createdAt) = :month")
+    Long getBuyCommissionByBrokerageId(@Param("brokerageId") UUID brokerageId,
+                                        @Param("transactionType") TransactionType transactionType,
+                                        @Param("year") int year,
+                                        @Param("month") int month);
+
+    /**
+     * 증권사별 월간 수익 조회 (매도 수수료)
+     * transactionType이 SELL이고 creditAccountId 또는 debitAccountId가 brokerageId와 일치하는 ledger의 commission 합계
+     * 
+     * @param brokerageId 증권사 ID
+     * @param year 년도
+     * @param month 월
+     * @return 매도 수수료 합계
+     */
+    @Query("SELECT COALESCE(SUM(l.commission), 0) FROM Ledger l " +
+           "WHERE l.transactionType = :transactionType " +
+           "AND (l.creditAccountId = :brokerageId OR l.debitAccountId = :brokerageId) " +
+           "AND l.commission IS NOT NULL AND l.commission > 0 " +
+           "AND YEAR(l.createdAt) = :year AND MONTH(l.createdAt) = :month")
+    Long getSellCommissionByBrokerageId(@Param("brokerageId") UUID brokerageId,
+                                         @Param("transactionType") TransactionType transactionType,
+                                         @Param("year") int year,
+                                         @Param("month") int month);
 }

--- a/ordering/src/main/java/com/beyond/MKX/domain/order/repository/OrderLogRepository.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/order/repository/OrderLogRepository.java
@@ -1,6 +1,8 @@
 package com.beyond.MKX.domain.order.repository;
 
 import com.beyond.MKX.domain.order.entity.OrderLog;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -9,5 +11,10 @@ import java.util.UUID;
 public interface OrderLogRepository extends JpaRepository<OrderLog, UUID> {
 
     Optional<OrderLog> findByIdAndAccount_Id(UUID orderLogId, UUID memberAccountId);
+
+    /**
+     * 증권사별 최근 주문 목록 조회
+     */
+    Page<OrderLog> findByBrokerageIdOrderByCreatedAtDesc(UUID brokerageId, Pageable pageable);
 
 }

--- a/ordering/src/main/java/com/beyond/MKX/domain/order/repository/OrderLogRepository.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/order/repository/OrderLogRepository.java
@@ -4,7 +4,10 @@ import com.beyond.MKX.domain.order.entity.OrderLog;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -17,4 +20,19 @@ public interface OrderLogRepository extends JpaRepository<OrderLog, UUID> {
      */
     Page<OrderLog> findByBrokerageIdOrderByCreatedAtDesc(UUID brokerageId, Pageable pageable);
 
+    /**
+     * 증권사별 오늘 주문한 고유 회원 계좌 수 조회
+     * 오늘(00:00 ~ 23:59:59) 안에 주문을 넣은 회원 계좌 수를 카운트
+     * 
+     * @param brokerageId 증권사 ID
+     * @param startDateTime 오늘 00:00:00
+     * @param endDateTime 오늘 23:59:59
+     * @return 오늘 주문한 고유 회원 계좌 수
+     */
+    @Query("SELECT COUNT(DISTINCT ol.account.id) FROM OrderLog ol " +
+           "WHERE ol.brokerageId = :brokerageId " +
+           "AND ol.createdAt >= :startDateTime AND ol.createdAt < :endDateTime")
+    Long countDistinctMemberAccountsByBrokerageIdAndDateRange(@Param("brokerageId") UUID brokerageId,
+                                                               @Param("startDateTime") LocalDateTime startDateTime,
+                                                               @Param("endDateTime") LocalDateTime endDateTime);
 }


### PR DESCRIPTION
## 📋 작업 개요
증권사 대시보드 기능을 전면 구현하고, 통계 로직과 데이터 조회 방식을 개선하였습니다.

<br/>

## 🔧 작업 상세
- **Repository 계층 확장**
  - 증권사별 데이터 조회용 메서드 추가  
  - 주문 내역, 거래내역, 보유 종목, 계좌 정보를 `brokerageId` 기준으로 조회 가능하도록 확장  

- **DTO 구조 정의**
  - 대시보드용 데이터 전송 객체(DTO) 추가  
  - 통계, 최근 활동, 주문 내역, 거래내역, 인기 종목 정보 DTO 설계  

- **Service 계층 구현**
  - 비즈니스 로직 통합 구현 (통계, 인기 종목, 최근 활동, 주문/거래내역 조회)  
  - 매수·매도 수수료를 `transactionType` 기준으로 분리 계산  
  - 월간 수익 계산 기준을 “이번 달” → “최근 30일”로 변경  
  - LedgerRepository에 날짜 범위 기반 수수료 조회 기능 추가  

- **REST API 컨트롤러 추가**
  - 증권사 대시보드용 REST API 엔드포인트 신규 생성  
  - 통계, 인기 종목, 최근 활동, 주문 내역, 거래내역 조회 기능 제공  
  - `X-User-Id` 헤더 기반 인증 및 `brokerageId` 자동 매핑 처리  

- **API 개선 및 확장**
  - 통계 데이터 조회 및 인기 종목 TOP 10 조회 API 구현  
  - 실시간 고객 활동 내역 조회 기능 추가  
  - 고객 목록 API에 계좌 잔고(accountBalance) 정보 추가  
  - 7일간 고객/계좌 변화량 비교 로직 추가  

<br/>

## 📌 이슈 번호
#122 

<br/>

## 🧪 테스트 결과
- Postman 및 통합 테스트를 통해 API 응답 검증 완료  
- 주요 시나리오:
  - 증권사별 거래내역 및 통계 데이터 정상 반환  
  - 최근 30일/이전 30일 수익 비교 정상 작동  
  - 고객 및 계좌 증감률 계산 검증  
- 응답 데이터의 수치 검증은 더미 데이터 기반으로 수행하였으며, DB 조회 로직 정상 동작 확인  

<br/>

## ⚠️ 참고사항
- 추후 실시간 데이터 반영을 위한 Redis Pub/Sub 및 SSE 연동 고려 예정  
- 통계 로직의 기준일자 설정은 차후 환경변수로 분리할 계획  

<br/>

## 👥 리뷰어 지정
@AstroJini @ggj0228 

<br/>

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  
- [x] develop 브랜치와 충돌 없이 병합 가능합니다.  
- [x] 통합 테스트 결과 및 로그를 확인했습니다.  
- [x] 최소 2명의 리뷰어를 지정했습니다.  
