### PR TITLE
[Feat] Redis 기반 거래량 통계 관리 및 통합 마켓 데이터 개선 (#148)

### DIFF
--- a/marketdata/src/main/java/com/beyond/MKX/domain/market/controller/MarketDataController.java
+++ b/marketdata/src/main/java/com/beyond/MKX/domain/market/controller/MarketDataController.java
@@ -1,19 +1,12 @@
 package com.beyond.MKX.domain.market.controller;
 
 import com.beyond.MKX.common.apiResponse.ApiResponse;
-import com.beyond.MKX.domain.market.dto.MarketDataDTO;
-import com.beyond.MKX.domain.orderbook.entity.OrderBook;
-import com.beyond.MKX.domain.orderbook.service.OrderBookService;
-import com.beyond.MKX.domain.price.entity.CurrentPrice;
-import com.beyond.MKX.domain.price.service.CurrentPriceService;
+import com.beyond.MKX.domain.orderbook.dto.enhanced.EnhancedOrderBookDTO;
+import com.beyond.MKX.domain.orderbook.service.EnhancedOrderBookService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.math.BigDecimal;
-import java.time.Instant;
-import java.util.ArrayList;
 
 /**
  * 통합 마켓 데이터 REST API Controller
@@ -27,8 +20,7 @@ import java.util.ArrayList;
 @RequiredArgsConstructor
 public class MarketDataController {
     
-    private final CurrentPriceService currentPriceService;
-    private final OrderBookService orderBookService;
+    private final EnhancedOrderBookService enhancedOrderBookService;
     
     /**
      * 통합 마켓 데이터 조회 (호가창 최적화)
@@ -48,53 +40,22 @@ public class MarketDataController {
         log.info("통합 마켓 데이터 조회: ticker={}, userId={}", ticker, userId);
         
         try {
-            // 1. 현재가 조회
-            CurrentPrice currentPrice = currentPriceService.getCurrentPrice(ticker);
+            // ✅ EnhancedOrderBookService를 사용하여 statistics 포함된 데이터 반환
+            EnhancedOrderBookDTO enhancedData = enhancedOrderBookService.getEnhancedOrderBook(ticker);
             
-            // 2. 호가 조회
-            log.info("[INTEGRATED-MARKET] 🔍 호가 조회 시작: ticker={}", ticker);
-            OrderBook orderBook = orderBookService.getOrderBook(ticker);
-            log.info("[INTEGRATED-MARKET] 📊 호가 조회 결과: ticker={}, bids={}, asks={}", 
-                ticker, orderBook != null ? orderBook.getBids().size() : 0, 
-                orderBook != null ? orderBook.getAsks().size() : 0);
+            if (enhancedData == null) {
+                log.warn("[INTEGRATED-MARKET] Enhanced data is null for ticker: {}", ticker);
+                return ApiResponse.noContent("통합 마켓 데이터를 조회할 수 없습니다");
+            }
             
-            // 3. 사용자 주문 조회 (Optional - 향후 구현)
-            // List<Long> userOrders = null;
-            // if (userId != null) {
-            //     userOrders = userOrderService.getUserOrderPrices(ticker, userId);
-            // }
+            log.info("[INTEGRATED-MARKET] ✅ 통합 마켓 데이터 조회 완료: ticker={}, bids={}, asks={}, totalBidVolume={}, totalAskVolume={}", 
+                ticker, 
+                enhancedData.getBids() != null ? enhancedData.getBids().size() : 0,
+                enhancedData.getAsks() != null ? enhancedData.getAsks().size() : 0,
+                enhancedData.getStatistics() != null ? enhancedData.getStatistics().getTotalBidVolume() : null,
+                enhancedData.getStatistics() != null ? enhancedData.getStatistics().getTotalAskVolume() : null);
             
-            // 4. DTO 조합 (초기 데이터 없을 경우 0으로 설정)
-            MarketDataDTO marketData = MarketDataDTO.builder()
-                .currentPrice(currentPrice != null ? currentPrice.getPrice() : 0L)
-                .prevClose(currentPrice != null ? currentPrice.getPrevClose() : 0L)
-                .open(currentPrice != null ? currentPrice.getOpen() : 0L)
-                .high(currentPrice != null ? currentPrice.getHigh() : 0L)
-                .low(currentPrice != null ? currentPrice.getLow() : 0L)
-                .change(currentPrice != null ? currentPrice.getChange() : 0L)
-                .changeRate(currentPrice != null && currentPrice.getChangeRate() != null ? 
-                    currentPrice.getChangeRate() : BigDecimal.ZERO)
-                .volume(currentPrice != null && currentPrice.getVolume() != null ? 
-                    currentPrice.getVolume() : BigDecimal.ZERO)
-                .volumeChange(currentPrice != null && currentPrice.getVolumeChange() != null ? 
-                    currentPrice.getVolumeChange() : BigDecimal.ZERO)
-                .prevVolume(currentPrice != null && currentPrice.getPrevVolume() != null ?
-                    currentPrice.getPrevVolume() : BigDecimal.ZERO)
-                .week52High(currentPrice != null ? currentPrice.getWeek52High() : 0L)
-                .week52Low(currentPrice != null ? currentPrice.getWeek52Low() : 0L)
-                .executionStrength(currentPrice != null && currentPrice.getExecutionStrength() != null ? 
-                    currentPrice.getExecutionStrength() : BigDecimal.ZERO)
-                .bids(orderBook != null ? orderBook.getBids() : new ArrayList<>())
-                .asks(orderBook != null ? orderBook.getAsks() : new ArrayList<>())
-                .userOrders(null) // 향후 구현
-                .timestamp(Instant.now())
-                .build();
-            
-            log.debug("통합 마켓 데이터 조회 완료: ticker={}, price={}, bids={}, asks={}", 
-                ticker, marketData.getCurrentPrice(), 
-                marketData.getBids().size(), marketData.getAsks().size());
-            
-            return ApiResponse.ok(marketData, "통합 마켓 데이터 조회 성공");
+            return ApiResponse.ok(enhancedData, "통합 마켓 데이터 조회 성공");
             
         } catch (Exception e) {
             log.error("통합 마켓 데이터 조회 실패: ticker={}", ticker, e);

--- a/marketdata/src/main/java/com/beyond/MKX/domain/orderbook/service/OrderBookStatisticsService.java
+++ b/marketdata/src/main/java/com/beyond/MKX/domain/orderbook/service/OrderBookStatisticsService.java
@@ -2,9 +2,10 @@ package com.beyond.MKX.domain.orderbook.service;
 
 import com.beyond.MKX.domain.orderbook.dto.enhanced.OrderBookStatistics;
 import com.beyond.MKX.domain.orderbook.entity.OrderBook;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -22,10 +23,21 @@ import java.util.concurrent.TimeUnit;
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class OrderBookStatisticsService {
     
     private final RedisTemplate<String, Object> redisTemplate;
+    private final StringRedisTemplate matchingEngineRedisTemplate;
+    
+    // ✅ @Qualifier와 함께 사용하려면 생성자 주입 필요
+    public OrderBookStatisticsService(
+            RedisTemplate<String, Object> redisTemplate,
+            @Qualifier("matchingEngineRedisTemplate") StringRedisTemplate matchingEngineRedisTemplate) {
+        this.redisTemplate = redisTemplate;
+        this.matchingEngineRedisTemplate = matchingEngineRedisTemplate;
+    }
+    
+    // Redis key prefix for total volume tracking (matching engine에서 관리)
+    private static final String TOTAL_VOLUME_KEY_PREFIX = "orderbook:total:";
     
     // Redis key prefix for execution volume tracking
     private static final String EXECUTION_VOLUME_KEY_PREFIX = "execution:volume:";
@@ -57,8 +69,37 @@ public class OrderBookStatisticsService {
             BigDecimal executionStrength = calculateExecutionStrength(recentBuyVolume, recentSellVolume);
             
             // 4. 총 매수/매도 잔량
-            BigDecimal totalBidVolume = calculateTotalVolume(orderBook.getBids());
-            BigDecimal totalAskVolume = calculateTotalVolume(orderBook.getAsks());
+            // ✅ matching engine Redis에서 관리하는 totalVolume 조회 (전체 대기 주문 합계)
+            BigDecimal totalBidVolume = getTotalVolumeFromRedis(ticker, "BUY");
+            BigDecimal totalAskVolume = getTotalVolumeFromRedis(ticker, "SELL");
+            
+            // ✅ Redis에서 값을 조회했는지 확인 (값이 0이어도 실제로는 0일 수 있으므로, 
+            //    Redis에서 null을 반환한 경우에만 fallback 사용)
+            // getTotalVolumeFromRedis는 조회 실패 시에만 ZERO를 반환하므로,
+            // 실제로는 값이 있을 때만 사용하고, 없을 때는 fallback 사용
+            
+            // 로깅으로 확인
+            log.info("[ORDERBOOK-STATS] Total volumes from Redis - ticker={}, bidVolume={}, askVolume={}", 
+                    ticker, totalBidVolume, totalAskVolume);
+            
+            // fallback: Redis에서 조회 실패(값이 없거나 에러) 시 호가창 데이터에서 계산 (상위 20개만)
+            // 주의: 실제 대기 주문이 0인 경우와 조회 실패를 구분하기 어려우므로,
+            // 호가창 데이터가 있고 Redis 값이 0이면 일단 호가창 데이터 사용
+            // (초기화 전 상황 대비)
+            if (totalBidVolume.compareTo(BigDecimal.ZERO) == 0 && !orderBook.getBids().isEmpty()) {
+                BigDecimal calculated = calculateTotalVolume(orderBook.getBids());
+                if (calculated.compareTo(BigDecimal.ZERO) > 0) {
+                    totalBidVolume = calculated;
+                    log.warn("[ORDERBOOK-STATS] Using fallback calculated bidVolume from orderbook: {} (Redis may not be initialized)", totalBidVolume);
+                }
+            }
+            if (totalAskVolume.compareTo(BigDecimal.ZERO) == 0 && !orderBook.getAsks().isEmpty()) {
+                BigDecimal calculated = calculateTotalVolume(orderBook.getAsks());
+                if (calculated.compareTo(BigDecimal.ZERO) > 0) {
+                    totalAskVolume = calculated;
+                    log.warn("[ORDERBOOK-STATS] Using fallback calculated askVolume from orderbook: {} (Redis may not be initialized)", totalAskVolume);
+                }
+            }
             
             // 5. 매수/매도 우위 비율
             BigDecimal bidRatio = calculateRatio(totalBidVolume, totalBidVolume, totalAskVolume);
@@ -199,7 +240,35 @@ public class OrderBookStatisticsService {
     }
     
     /**
-     * 총 호가 수량 계산
+     * Redis에서 총 호가 잔량 조회 (matching engine에서 관리)
+     */
+    private BigDecimal getTotalVolumeFromRedis(String ticker, String side) {
+        try {
+            String key = TOTAL_VOLUME_KEY_PREFIX + "{" + ticker + "}";
+            String field = side.equalsIgnoreCase("BUY") ? "bidVolume" : "askVolume";
+            
+            // ✅ matching engine Redis에서 조회 (StringRedisTemplate 사용)
+            String value = (String) matchingEngineRedisTemplate.opsForHash().get(key, field);
+            
+            if (value != null && !value.isEmpty()) {
+                try {
+                    // StringRedisTemplate은 String을 반환하므로 바로 BigDecimal로 변환
+                    return new BigDecimal(value);
+                } catch (NumberFormatException e) {
+                    log.warn("[ORDERBOOK-STATS] Failed to parse total volume: ticker={}, side={}, value={}", ticker, side, value);
+                }
+            } else {
+                log.debug("[ORDERBOOK-STATS] Total volume not found in Redis: ticker={}, side={}, key={}, field={}", ticker, side, key, field);
+            }
+        } catch (Exception e) {
+            log.warn("[ORDERBOOK-STATS] Failed to get total volume from Redis: ticker={}, side={}", ticker, side, e);
+        }
+        
+        return BigDecimal.ZERO;
+    }
+    
+    /**
+     * 총 호가 수량 계산 (fallback용 - 호가창 데이터에서 계산)
      */
     private BigDecimal calculateTotalVolume(java.util.List<OrderBook.OrderBookEntry> entries) {
         if (entries == null || entries.isEmpty()) {

--- a/matching-engine/src/main/java/com/beyond/MKX/domain/order/repository/RedisOrderRepository.java
+++ b/matching-engine/src/main/java/com/beyond/MKX/domain/order/repository/RedisOrderRepository.java
@@ -70,6 +70,15 @@ public class RedisOrderRepository {
         final String sideKey = side.equalsIgnoreCase("BUY") ? "bids" : "asks";
         return "seq:{" + ticker + "}:" + sideKey;
     }
+    
+    /**
+     * 총 호가 잔량 키 (Redis HASH)
+     * key: orderbook:total:{ticker}
+     * fields: bidVolume, askVolume
+     */
+    private String totalVolumeKey(String ticker) {
+        return "orderbook:total:{" + ticker + "}";
+    }
 
     // ----------------------------------------------------------------------
     // KRW 가격 정수화/복원 (정수 가격 저장 정책)
@@ -117,6 +126,9 @@ public class RedisOrderRepository {
         idx.put("ticker", ticker);
         idx.put("side", side);
         redisTemplate.opsForHash().putAll(idxKey, idx);
+        
+        // ✅ 총 호가 잔량 증가
+        incrementTotalVolume(ticker, side, quantity);
     }
 
     // ----------------------------------------------------------------------
@@ -124,9 +136,72 @@ public class RedisOrderRepository {
     // ----------------------------------------------------------------------
     public void cancelOrder(String orderId, String ticker, String side) {
         final String bookKey = orderBookKey(ticker, side);
+        final String detailKey = orderDetailKey(ticker, orderId);
+        
+        // 주문 수량 조회 (총량 감소용)
+        String quantityStr = (String) redisTemplate.opsForHash().get(detailKey, "quantity");
+        BigDecimal quantity = null;
+        if (quantityStr != null) {
+            try {
+                quantity = new BigDecimal(quantityStr);
+            } catch (NumberFormatException e) {
+                // 수량 파싱 실패 시 무시
+            }
+        }
+        
         redisTemplate.opsForZSet().remove(bookKey, orderId);
-        redisTemplate.delete(orderDetailKey(ticker, orderId));
+        redisTemplate.delete(detailKey);
         redisTemplate.delete(orderIndexKey(orderId));
+        
+        // ✅ 총 호가 잔량 감소
+        if (quantity != null) {
+            decrementTotalVolume(ticker, side, quantity);
+        }
+    }
+    
+    // ----------------------------------------------------------------------
+    // 총 호가 잔량 관리
+    // ----------------------------------------------------------------------
+    
+    /**
+     * 총 호가 잔량 증가
+     */
+    public void incrementTotalVolume(String ticker, String side, BigDecimal quantity) {
+        final String totalKey = totalVolumeKey(ticker);
+        final String field = side.equalsIgnoreCase("BUY") ? "bidVolume" : "askVolume";
+        redisTemplate.opsForHash().increment(totalKey, field, quantity.doubleValue());
+    }
+    
+    /**
+     * 총 호가 잔량 감소
+     */
+    public void decrementTotalVolume(String ticker, String side, BigDecimal quantity) {
+        final String totalKey = totalVolumeKey(ticker);
+        final String field = side.equalsIgnoreCase("BUY") ? "bidVolume" : "askVolume";
+        redisTemplate.opsForHash().increment(totalKey, field, -quantity.doubleValue());
+    }
+    
+    /**
+     * 총 호가 잔량 조회
+     */
+    public BigDecimal getTotalVolume(String ticker, String side) {
+        final String totalKey = totalVolumeKey(ticker);
+        final String field = side.equalsIgnoreCase("BUY") ? "bidVolume" : "askVolume";
+        Object value = redisTemplate.opsForHash().get(totalKey, field);
+        if (value == null) {
+            return BigDecimal.ZERO;
+        }
+        if (value instanceof Number) {
+            return BigDecimal.valueOf(((Number) value).doubleValue());
+        }
+        if (value instanceof String) {
+            try {
+                return new BigDecimal((String) value);
+            } catch (NumberFormatException e) {
+                return BigDecimal.ZERO;
+            }
+        }
+        return BigDecimal.ZERO;
     }
 
     // ----------------------------------------------------------------------

--- a/matching-engine/src/main/java/com/beyond/MKX/domain/order/service/MatchingEngineService.java
+++ b/matching-engine/src/main/java/com/beyond/MKX/domain/order/service/MatchingEngineService.java
@@ -27,7 +27,7 @@ public class MatchingEngineService {
     private final KafkaOrderProducer kafkaOrderProducer;
 
     /** 한 번의 Lua 실행에서 소비할 최대 매칭 수(과도한 처리 방지) */
-    private static final int MAX_MATCHES_PER_CALL = 200;
+    private static final int MAX_MATCHES_PER_CALL = Integer.MAX_VALUE;
 
     /** BigDecimal 수량이 정수인지 검증하고 long으로 변환(정수가 아니면 예외) */
     private static long toUnitsExact(BigDecimal q, String fieldName) {
@@ -114,6 +114,8 @@ public class MatchingEngineService {
 
             // 외부 이벤트용 BigDecimal 수량은 그대로 전달(정수이지만 타입 유지)
             filledQtyBD = filledQtyBD.add(f.quantity());
+
+            // ✅ totalVolume은 이제 Lua 스크립트에서 원자적으로 관리하므로 Java에서 중복 감소하지 않음
 
             kafkaOrderProducer.sendExecution(
                     e.getOrderId(),
@@ -215,6 +217,8 @@ public class MatchingEngineService {
             lastPxInt       = px;
 
             filledQtyBD = filledQtyBD.add(f.quantity());
+
+            // ✅ totalVolume은 이제 Lua 스크립트에서 원자적으로 관리하므로 Java에서 중복 감소하지 않음
 
             kafkaOrderProducer.sendExecution(
                     mkt.getOrderId(),

--- a/matching-engine/src/main/resources/lua/market_match.lua
+++ b/matching-engine/src/main/resources/lua/market_match.lua
@@ -1,6 +1,8 @@
 -- KEYS:
 --   KEYS[1] = orderbook:{ticker}:bids        -- 매수 호가 ZSET (score = priceInt, 높은 값 우선)
 --   KEYS[2] = orderbook:{ticker}:asks        -- 매도 호가 ZSET (score = priceInt, 낮은 값 우선)
+--   KEYS[3] = seq:{ticker}:bids              -- 매수 시퀀스
+--   KEYS[4] = seq:{ticker}:asks              -- 매도 시퀀스
 --
 -- ARGV:
 --   1: ticker
@@ -10,6 +12,7 @@
 --   5: guardPxInt (int or nil-string)        -- 가격 가드(시장가면 nil/빈문자)
 --   6: orderIdToAdd (string)                 -- LIMIT 잔량 적재용(시장가면 "")
 --   7: priceIntForAdd (int)                  -- LIMIT 잔량 적재 가격(시장가면 0)
+--   8: FACTOR                                 -- 가격·시간 tie-breaker 스케일
 --
 -- 주문 상세 해시(HASH) 스키마(동일 {ticker} 해시태그 슬롯 사용 필수):
 --   orders:{ticker}:{orderId}  -- fields: quantity(string), priceInt(string), side, ticker
@@ -21,6 +24,10 @@ local max_matches    = tonumber(ARGV[4])
 local guardPxInt_raw = ARGV[5]
 local orderIdToAdd   = ARGV[6] or ""
 local priceIntForAdd = tonumber(ARGV[7] or "0")
+local FACTOR         = tonumber(ARGV[8]) or 1000000
+
+-- ✅ totalVolume 관리용 키
+local totalVolumeKey = "orderbook:total:{" .. ticker .. "}"
 
 if not qty_left or qty_left <= 0 then
   return { "0", "0" }
@@ -109,6 +116,11 @@ while qty_left > 0 and matchCount < max_matches do
           redis.call("HSET", oKey, "quantity", tostring(remain))
         end
 
+        -- ✅ 체결 시 counter order의 totalVolume 감소 (양쪽 side 모두 감소)
+        -- counter order의 side가 oppositeSide이므로, oppositeSide의 totalVolume 감소
+        local oppositeField = (oppositeSide == "BUY") and "bidVolume" or "askVolume"
+        redis.call("HINCRBYFLOAT", totalVolumeKey, oppositeField, -fill)
+
         table.insert(matches, topId)
         table.insert(matches, tostring(fill))
         table.insert(matches, tostring(priceInt))
@@ -153,6 +165,10 @@ if qty_left > 0 and orderIdToAdd ~= "" then
           "priceInt", tostring(priceIntForAdd)
   )
   redis.call("ZADD", zsetKey, score, orderIdToAdd)
+  
+  -- ✅ 새 주문 추가 시 totalVolume 증가
+  local addField = (addSide == "BUY") and "bidVolume" or "askVolume"
+  redis.call("HINCRBYFLOAT", totalVolumeKey, addField, qty_left)
 end
 
 -- out: [ remaining, matchCount, orderId1, fill1, priceInt1, ... ]

--- a/ordering/src/main/java/com/beyond/MKX/domain/order/dto/OrderRequestDTO.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/order/dto/OrderRequestDTO.java
@@ -25,7 +25,7 @@ public record OrderRequestDTO(
 
         @NotNull(message = "주문 수량을 입력하세요.")
         @Min(value = 1, message = "주문 수량은 1주 이상이어야 합니다.")
-        @Max(value = 100000, message = "10만 주를 초과할 수 없습니다.")
+//        @Max(value = 100000, message = "10만 주를 초과할 수 없습니다.")
         Long quantity
 ) {
 }

--- a/trading-bot/src/main/java/com/beyond/MKX/domain/tradingBot/dto/OrderRequestDTO.java
+++ b/trading-bot/src/main/java/com/beyond/MKX/domain/tradingBot/dto/OrderRequestDTO.java
@@ -28,7 +28,7 @@ public record OrderRequestDTO(
 
         @NotNull(message = "주문 수량을 입력하세요.")
         @Min(value = 1, message = "주문 수량은 1주 이상이어야 합니다.")
-        @Max(value = 100000, message = "10만 주를 초과할 수 없습니다.")
+//        @Max(value = 100000, message = "10만 주를 초과할 수 없습니다.")
         Long quantity
 ) {
 }


### PR DESCRIPTION
## 📋 작업 개요  
**Redis 기반 거래량 통계 관리 및 통합 마켓 데이터 개선**

<br/>

## 🔧 작업 상세  
- **Redis 거래량 관리 로직 추가**  
  - `orderbook:total:{ticker}` 키 구조 도입  
  - `bidVolume`, `askVolume` 필드 기반 거래량 증감 관리  
  - 주문 생성·취소 시 `HINCRBYFLOAT`를 이용해 실시간 누적 반영  
  - 장애 대비 BigDecimal 변환 및 예외 처리 보강  

- **Lua 매칭 스크립트 통합**  
  - 체결 발생 시 반대 side 거래량 감소 및 잔량 반영 로직 추가  
  - 매칭 루프 내 일관성 보장을 위한 원자적 카운터 관리  
  - 중복 통계 처리를 방지하고 Java 단 로직 최소화  

- **Market Data API 개선**  
  - `EnhancedOrderBookService` 기반 통합 응답 구조로 개편  
  - 총 매수/매도 거래량(`totalBidVolume`, `totalAskVolume`) 및 통계 포함  
  - 로그 상세화로 ticker별 데이터 추적성 강화  

- **기타 최적화 및 설정 변경**  
  - `MAX_MATCHES_PER_CALL` 상한을 `Integer.MAX_VALUE`로 확장  
  - 주문 수량 상한 제한(`@Max(100000)`) 임시 해제 → 테스트 목적  
  - Kafka 이벤트 전송 및 Lua 연동 주석 보강  

<br/>

## 📌 이슈 번호  
Feature148  

<br/>

## 🧪 테스트 결과  
- Redis 연결 및 Lua 스크립트 연동 정상 작동  
- 체결 발생 시 거래량 실시간 반영 확인  
- Redis 비정상 응답 시 폴백(fallback) 로직 정상 작동  
- Market Data API에서 통합 거래량 데이터 검증 완료  

<br/>

## ⚠️ 참고사항  
- 수량 제한은 추후 팀 논의 후 재설정 예정  
- Redis 장애 시에도 로컬 계산값으로 복원 가능  

<br/>

## 👥 리뷰어 지정  
@ggj0228 @AstroJini  

<br/>

## ✅ PR Checklist  
- [x] 커밋 메시지 컨벤션 준수  
- [x] develop 브랜치 Pull 및 충돌 해결  
- [x] 테스트 완료 및 로그 검증  
- [x] 2인 리뷰어 지정 완료  
