### PR TITLE
[Feat] 주문 조회·취소 로직 확장 및 인증 화이트리스트 구조 개선 (#153)

### DIFF
--- a/apigateway/src/main/java/com/beyond/MKX/common/auth/filter/CsrfFilter.java
+++ b/apigateway/src/main/java/com/beyond/MKX/common/auth/filter/CsrfFilter.java
@@ -45,7 +45,8 @@ public class CsrfFilter implements GlobalFilter, Ordered {
     private static final List<String> CSRF_WHITELIST = List.of(
             "/auth/**",   // 로그인/회원가입 등 인증 관련 엔드포인트
             "/health",     // 헬스체크
-            "/order/**",
+            "/order",  // POST /order (주문 접수)만 허용
+            "/order/test/**",  // 테스트용 엔드포인트
             "/test/**",
             "/public/**",
             "/api/stocks/**",

--- a/apigateway/src/main/java/com/beyond/MKX/common/auth/filter/JwtAuthFilter.java
+++ b/apigateway/src/main/java/com/beyond/MKX/common/auth/filter/JwtAuthFilter.java
@@ -63,7 +63,8 @@ public class JwtAuthFilter implements GlobalFilter, Ordered {
     private static final List<String> AUTH_WHITELIST = List.of(
             "/auth/**",
             "/health",
-            "/order/**",
+            "/order",  // POST /order (주문 접수)만 허용
+            "/order/test/**",  // 테스트용 엔드포인트
             "/test/**",
             "/public/**",
 //            "/ipo/**"

--- a/marketdata/src/main/java/com/beyond/MKX/domain/orderbook/consumer/OrderStatusKafkaConsumer.java
+++ b/marketdata/src/main/java/com/beyond/MKX/domain/orderbook/consumer/OrderStatusKafkaConsumer.java
@@ -73,7 +73,7 @@ public class OrderStatusKafkaConsumer {
                 shouldUpdateTurnover = true;
                 log.debug("[ORDER-STATUS] Execution occurred - orderbook & turnover update required: ticker={}, status={}", 
                         ticker, status);
-            } else if ("CANCELLED".equals(status)) {
+            } else if ("CANCEL_OK".equals(status)) {
                 // 주문 취소 - 호가 업데이트 필요
                 shouldUpdateOrderBook = true;
                 log.debug("[ORDER-STATUS] Order cancelled - orderbook update required: ticker={}, status={}", 

--- a/matching-engine/src/main/java/com/beyond/MKX/domain/order/service/MatchingEngineService.java
+++ b/matching-engine/src/main/java/com/beyond/MKX/domain/order/service/MatchingEngineService.java
@@ -274,8 +274,8 @@ public class MatchingEngineService {
         requireNonEmpty(e.getSide(),   "side");
 
         redisRepo.cancelOrder(e.getOrderId(), e.getTicker(), e.getSide());
-        kafkaOrderProducer.sendCancelSuccess(e.getOrderId());
-        log.info("CANCEL ok: {}", e.getOrderId());
+        kafkaOrderProducer.sendCancelSuccess(e.getOrderId(), e.getTicker(), e.getSide());
+        log.info("CANCEL ok: {} ticker={} side={}", e.getOrderId(), e.getTicker(), e.getSide());
     }
 
     // ----------------------------------------------------------------------

--- a/matching-engine/src/main/java/com/beyond/MKX/infrastructure/kafka/KafkaOrderProducer.java
+++ b/matching-engine/src/main/java/com/beyond/MKX/infrastructure/kafka/KafkaOrderProducer.java
@@ -79,11 +79,15 @@ public class KafkaOrderProducer {
     }
 
     /** 취소 성공 */
-    public void sendCancelSuccess(String orderId) {
+    public void sendCancelSuccess(String orderId, String ticker, String side) {
         OrderStatusEvent evt = OrderStatusEvent.builder()
-                .orderId(orderId).status("CANCEL_OK")
-                .timestamp(Instant.now().toEpochMilli()).build();
-        sendOrderStatus(orderId, evt);        // 키=orderId (특정 주문 추적)
+                .orderId(orderId)
+                .ticker(ticker)
+                .side(side)
+                .status("CANCEL_OK")
+                .timestamp(Instant.now().toEpochMilli())
+                .build();
+        sendOrderStatus(ticker != null ? ticker : orderId, evt);
     }
 
     /** 시장가 대기(가드 범위 내 반대 호가 없음) */

--- a/ordering/src/main/java/com/beyond/MKX/domain/order/controller/OrderController.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/order/controller/OrderController.java
@@ -4,14 +4,18 @@ import com.beyond.MKX.common.apiResponse.ApiResponse;
 import com.beyond.MKX.domain.order.dto.OrderCancelRequestDTO;
 import com.beyond.MKX.domain.order.dto.OrderRequestDTO;
 import com.beyond.MKX.domain.order.dto.OrderResponseDTO;
+import com.beyond.MKX.domain.order.dto.PendingOrderResponseDTO;
 import com.beyond.MKX.domain.order.service.OrderBookService;
 import com.beyond.MKX.domain.order.service.OrderService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -42,6 +46,24 @@ public class OrderController {
         return ApiResponse.ok(resDTO);
     }
 
+    @GetMapping("/pending")
+    public ResponseEntity<?> getPendingOrders(
+            @RequestHeader("X-User-Id") UUID memberId,
+            @PageableDefault(size = 15) Pageable pageable
+    ) {
+        Page<PendingOrderResponseDTO> pendingOrders = orderService.getPendingOrders(memberId, pageable);
+        return ApiResponse.ok(pendingOrders);
+    }
+
+    @GetMapping("/history/{ticker}")
+    public ResponseEntity<?> getOrderHistoryByTicker(
+            @RequestHeader("X-User-Id") UUID memberId,
+            @PathVariable String ticker,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        Page<OrderResponseDTO> orderHistory = orderService.getOrderHistoryByTicker(memberId, ticker, pageable);
+        return ApiResponse.ok(orderHistory);
+    }
 
     /**
      * test 목적 '최저 매도가' 조회 매핑

--- a/ordering/src/main/java/com/beyond/MKX/domain/order/dto/OrderResponseDTO.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/order/dto/OrderResponseDTO.java
@@ -1,12 +1,15 @@
 package com.beyond.MKX.domain.order.dto;
 
+import com.beyond.MKX.domain.order.entity.OrderKind;
 import com.beyond.MKX.domain.order.entity.OrderLog;
 import com.beyond.MKX.domain.order.entity.OrderStatus;
+import com.beyond.MKX.domain.order.entity.Side;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @AllArgsConstructor
@@ -16,8 +19,25 @@ import java.util.UUID;
 public class OrderResponseDTO {
     private UUID orderId;
     private OrderStatus orderStatus;
+    private String ticker;
+    private Side side;
+    private Long price;
+    private Long quantity;
+    private Long remainQuantity;
+    private OrderKind orderKind;
+    private LocalDateTime createdAt;
 
     public static OrderResponseDTO from(OrderLog order) {
-        return OrderResponseDTO.builder().orderId(order.getId()).orderStatus(order.getStatus()).build();
+        return OrderResponseDTO.builder()
+                .orderId(order.getId())
+                .orderStatus(order.getStatus())
+                .ticker(order.getTicker())
+                .side(order.getSide())
+                .price(order.getPrice())
+                .quantity(order.getQuantity())
+                .remainQuantity(order.getRemainQuantity())
+                .orderKind(order.getOrderKind())
+                .createdAt(order.getCreatedAt())
+                .build();
     }
 }

--- a/ordering/src/main/java/com/beyond/MKX/domain/order/dto/PendingOrderResponseDTO.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/order/dto/PendingOrderResponseDTO.java
@@ -1,0 +1,44 @@
+package com.beyond.MKX.domain.order.dto;
+
+import com.beyond.MKX.domain.order.entity.OrderKind;
+import com.beyond.MKX.domain.order.entity.OrderLog;
+import com.beyond.MKX.domain.order.entity.OrderStatus;
+import com.beyond.MKX.domain.order.entity.Side;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+public class PendingOrderResponseDTO {
+    private UUID orderId;
+    private String ticker;
+    private Side side;
+    private Long price;
+    private Long quantity;
+    private Long remainQuantity;
+    private OrderKind orderKind;
+    private OrderStatus status;
+    private LocalDateTime createdAt;
+
+    public static PendingOrderResponseDTO from(OrderLog order) {
+        return PendingOrderResponseDTO.builder()
+                .orderId(order.getId())
+                .ticker(order.getTicker())
+                .side(order.getSide())
+                .price(order.getPrice())
+                .quantity(order.getQuantity())
+                .remainQuantity(order.getRemainQuantity())
+                .orderKind(order.getOrderKind())
+                .status(order.getStatus())
+                .createdAt(order.getCreatedAt())
+                .build();
+    }
+}
+

--- a/ordering/src/main/java/com/beyond/MKX/domain/order/repository/OrderLogRepository.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/order/repository/OrderLogRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -35,4 +36,54 @@ public interface OrderLogRepository extends JpaRepository<OrderLog, UUID> {
     Long countDistinctMemberAccountsByBrokerageIdAndDateRange(@Param("brokerageId") UUID brokerageId,
                                                                @Param("startDateTime") LocalDateTime startDateTime,
                                                                @Param("endDateTime") LocalDateTime endDateTime);
+
+    /**
+     * 회원의 대기 중인 주문 조회
+     * - 지정가(LIMIT) 또는 예약(RESERVED) 주문
+     * - 상태가 PENDING 또는 PARTIALLY_FILLED인 주문
+     * 
+     * @param memberId 회원 ID
+     * @return 대기 중인 주문 목록 (최신순)
+     */
+    @Query("SELECT ol FROM OrderLog ol " +
+           "WHERE ol.account.memberId = :memberId " +
+           "AND ol.orderKind IN ('LIMIT', 'RESERVED') " +
+           "AND ol.status IN ('PENDING', 'PARTIALLY_FILLED') " +
+           "ORDER BY ol.createdAt DESC")
+    List<OrderLog> findPendingOrdersByMemberId(@Param("memberId") UUID memberId);
+
+    /**
+     * 회원의 대기 중인 주문 조회 (페이징)
+     * - 지정가(LIMIT) 또는 예약(RESERVED) 주문
+     * - 상태가 PENDING 또는 PARTIALLY_FILLED인 주문
+     * 
+     * @param memberId 회원 ID
+     * @param pageable 페이지 정보
+     * @return 대기 중인 주문 목록 (최신순, 페이징)
+     */
+    @Query("SELECT ol FROM OrderLog ol " +
+           "WHERE ol.account.memberId = :memberId " +
+           "AND ol.orderKind IN ('LIMIT', 'RESERVED') " +
+           "AND ol.status IN ('PENDING', 'PARTIALLY_FILLED') " +
+           "ORDER BY ol.createdAt DESC")
+    Page<OrderLog> findPendingOrdersByMemberId(@Param("memberId") UUID memberId, Pageable pageable);
+
+    /**
+     * 회원의 특정 종목에 대한 주문 로그 조회 (페이징)
+     * - 모든 상태의 주문 포함
+     * 
+     * @param memberId 회원 ID
+     * @param ticker 종목 코드
+     * @param pageable 페이지 정보
+     * @return 주문 로그 목록 (최신순, 페이징)
+     */
+    @Query("SELECT ol FROM OrderLog ol " +
+           "WHERE ol.account.memberId = :memberId " +
+           "AND ol.ticker = :ticker " +
+           "ORDER BY ol.createdAt DESC")
+    Page<OrderLog> findByMemberIdAndTickerOrderByCreatedAtDesc(
+            @Param("memberId") UUID memberId,
+            @Param("ticker") String ticker,
+            Pageable pageable
+    );
 }

--- a/ordering/src/main/java/com/beyond/MKX/domain/order/service/OrderService.java
+++ b/ordering/src/main/java/com/beyond/MKX/domain/order/service/OrderService.java
@@ -8,9 +8,9 @@ import com.beyond.MKX.domain.order.dto.CommissionAndTaxData;
 import com.beyond.MKX.domain.order.dto.OrderCancelRequestDTO;
 import com.beyond.MKX.domain.order.dto.OrderRequestDTO;
 import com.beyond.MKX.domain.order.dto.OrderResponseDTO;
+import com.beyond.MKX.domain.order.dto.PendingOrderResponseDTO;
 import com.beyond.MKX.domain.order.entity.OrderKind;
 import com.beyond.MKX.domain.order.entity.OrderLog;
-import com.beyond.MKX.domain.order.entity.OrderStatus;
 import com.beyond.MKX.domain.order.entity.Side;
 import com.beyond.MKX.domain.order.repository.OrderLogRepository;
 import com.beyond.MKX.domain.outbox.entity.OrderOutbox;
@@ -23,10 +23,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -168,6 +173,41 @@ public class OrderService {
                         .build()
         );
         return OrderResponseDTO.from(orderLog);
+    }
+
+    // 대기 중인 주문 조회 서비스 로직
+    @Transactional(readOnly = true)
+    public List<PendingOrderResponseDTO> getPendingOrders(UUID memberId) {
+        // 계좌 존재 여부 확인
+        memberAccountRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 계좌를 찾을 수 없습니다."));
+
+        List<OrderLog> orderLogs = orderLogRepository.findPendingOrdersByMemberId(memberId);
+        return orderLogs.stream()
+                .map(PendingOrderResponseDTO::from)
+                .collect(Collectors.toList());
+    }
+
+    // 대기 중인 주문 조회 서비스 로직 (페이징)
+    @Transactional(readOnly = true)
+    public Page<PendingOrderResponseDTO> getPendingOrders(UUID memberId, Pageable pageable) {
+        // 계좌 존재 여부 확인
+        memberAccountRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 계좌를 찾을 수 없습니다."));
+
+        Page<OrderLog> orderLogsPage = orderLogRepository.findPendingOrdersByMemberId(memberId, pageable);
+        return orderLogsPage.map(PendingOrderResponseDTO::from);
+    }
+
+    // 특정 종목의 주문 히스토리 조회 서비스 로직 (페이징)
+    @Transactional(readOnly = true)
+    public Page<OrderResponseDTO> getOrderHistoryByTicker(UUID memberId, String ticker, Pageable pageable) {
+        // 계좌 존재 여부 확인
+        memberAccountRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 계좌를 찾을 수 없습니다."));
+
+        Page<OrderLog> orderLogsPage = orderLogRepository.findByMemberIdAndTickerOrderByCreatedAtDesc(memberId, ticker, pageable);
+        return orderLogsPage.map(OrderResponseDTO::from);
     }
 
 


### PR DESCRIPTION
## 📋 작업 개요  
주문 조회·취소 기능 확장 및 인증 화이트리스트 구조 개선  

<br/>

## 🔧 작업 상세  
- **CSRF / JWT 인증 화이트리스트 개선**
  - `/order/**` → `/order/`로 축소하여 POST 주문 접수만 허용
  - `/order/test/**` 테스트용 엔드포인트 추가
  - 인증 및 헬스체크 외 주요 내부 엔드포인트 접근성 개선  

- **주문 상태 및 Kafka 이벤트 처리 개선**
  - Kafka Consumer의 상태 코드 `"CANCELLED"` → `"CANCEL_OK"`로 수정
  - `sendCancelSuccess()` 호출 시 `ticker`, `side` 인자 추가
  - `OrderStatusEvent` 빌더 확장 및 로그 포맷 개선으로 주문 추적성 강화  

- **주문 조회 API 신규 추가**
  - `/pending`: 회원별 대기 주문 조회
  - `/history/{ticker}`: 티커별 주문 이력 조회  
  - `@RequestHeader("X-User-Id")`, `@PageableDefault` 기반 페이징 처리 적용  

- **DTO 및 Repository 확장**
  - `OrderResponseDTO`: `ticker`, `side`, `price`, `remainQuantity`, `createdAt` 필드 추가  
  - `PendingOrderResponseDTO`: 미체결 주문 전용 DTO 신규 생성  
  - `OrderLogRepository`: 회원별/티커별 미체결 주문 조회 쿼리 구현  

- **Service 계층 로직 추가**
  - `getPendingOrders()`, `getOrderHistoryByTicker()` 메서드 구현  
  - DTO 매핑 일원화로 일관된 응답 구조 유지  

<br/>

## 📌 이슈 번호  
close #153  

<br/>

## 🧪 테스트 결과  
- API 엔드포인트 호출 시 대기 주문·이력 조회 정상 작동 확인  
- 주문 취소 시 `CANCEL_OK` 이벤트 발행 및 Kafka 로그 정상 출력  
- 인증 화이트리스트 경로를 통한 `/order` 요청 정상 통과 검증  

<br/>

## ⚠️ 참고사항  
- 추후 체결 이력 조회 및 상태 필터링 추가 예정  

<br/>

## 👥 리뷰어 지정  
@AstroJini @ggj0228  

<br/>