### PR TITLE
[Fix] STOMP WebSocket CORS 설정 충돌 및 불필요 변수 정리 (#164)

### DIFF
--- a/marketdata/src/main/java/com/beyond/MKX/common/config/websocket/OptionalAuthChannelInterceptor.java
+++ b/marketdata/src/main/java/com/beyond/MKX/common/config/websocket/OptionalAuthChannelInterceptor.java
@@ -48,9 +48,6 @@ public class OptionalAuthChannelInterceptor implements ChannelInterceptor {
     @Value("${jwt.secretKeyAt:default-secret-key-for-development-only-minimum-256-bits}")
     private String jwtSecret;
 
-    @Value("${jwt.expiration:86400000}")
-    private long jwtExpiration;
-
     /**
      * 메시지 전송 전 인터셉트
      *

--- a/marketdata/src/main/java/com/beyond/MKX/common/config/websocket/StompWebSocketConfig.java
+++ b/marketdata/src/main/java/com/beyond/MKX/common/config/websocket/StompWebSocketConfig.java
@@ -2,7 +2,6 @@ package com.beyond.MKX.common.config.websocket;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
@@ -26,29 +25,28 @@ public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
     private final OptionalAuthChannelInterceptor optionalAuthChannelInterceptor;
     private final RateLimitingInterceptor rateLimitingInterceptor;
 
-    @Value("${spring.data.redis.host:localhost}")
-    private String redisHost;
-
-    @Value("${spring.data.redis.port:6379}")
-    private int redisPort;
-
     /**
      * STOMP 엔드포인트 등록
      *
      * SockJS fallback 지원
+     * 
+     * ⚠️ 주의: setAllowedOriginPatterns와 setAllowedOrigins를 동시에 사용할 수 없음
+     * setAllowCredentials(true)를 사용하므로 setAllowedOrigins 사용 (와일드카드 불가)
      */
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                .setAllowedOriginPatterns("*")
                 .setAllowedOrigins(
                         "http://localhost:3000",
                         "http://localhost:3001",
-                        "https://www.trading.mk-exchange.shop"
+                        "https://trading.mk-exchange.shop",
+                        "https://www.trading.mk-exchange.shop",
+                        "https://managing.mk-exchange.shop"
                 )
                 .withSockJS();
 
         log.info("[STOMP] ✅ Registered STOMP endpoint: /ws with SockJS");
+        log.info("[STOMP]   - Allowed origins: localhost:3000, localhost:3001, trading.mk-exchange.shop");
     }
 
     /**

--- a/marketdata/src/main/java/com/beyond/MKX/common/config/websocket/WebSocketSecurityConfig.java
+++ b/marketdata/src/main/java/com/beyond/MKX/common/config/websocket/WebSocketSecurityConfig.java
@@ -82,10 +82,13 @@ public class WebSocketSecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         
         // Origin 설정 (✅ allowedOrigins만 사용 - allowedOriginPatterns과 충돌 방지)
+        // setAllowCredentials(true)를 사용하므로 와일드카드 패턴 사용 불가
         configuration.setAllowedOrigins(Arrays.asList(
                 "http://localhost:3000",
                 "http://localhost:3001",
-                "https://www.trading.mk-exchange.shop"
+                "https://trading.mk-exchange.shop",
+                "https://www.trading.mk-exchange.shop",
+                "https://managing.mk-exchange.shop"
         ));
 
         // HTTP 메소드
@@ -114,7 +117,7 @@ public class WebSocketSecurityConfig {
         source.registerCorsConfiguration("/**", configuration);
 
         log.info("[SECURITY] ✅ CORS configured");
-        log.info("[SECURITY]   - Allowed origins: localhost:3000, localhost:3001");
+        log.info("[SECURITY]   - Allowed origins: localhost:3000, localhost:3001, trading.mk-exchange.shop, managing.mk-exchange.shop");
         log.info("[SECURITY]   - Credentials: allowed");
         
         return source;


### PR DESCRIPTION
## 📋 작업 개요
STOMP WebSocket의 CORS 설정 충돌 해결 및 불필요한 인증 인터셉터 변수 정리

<br/>

## 🔧 작업 상세
- setAllowedOriginPatterns("*")와 setAllowedOrigins() 동시 사용으로 인한 충돌 제거  
- setAllowCredentials(true) 사용 시 와일드카드 패턴 불가 이슈 해결 → setAllowedOrigins()만 유지  
- 프로덕션 도메인(trading.mk-exchange.shop, managing.mk-exchange.shop) CORS 허용 목록에 추가  
- OptionalAuthChannelInterceptor 내부 미사용 변수(jwtExpiration, redisHost, redisPort) 제거  
- 불필요한 @Value import 문 삭제로 코드 가독성 및 유지보수성 개선  

<br/>

## 📌 이슈 번호
close #164 

<br/>

## 🧪 테스트 결과
- 로컬 환경에서 WebSocket 연결 정상 확인 (STOMP 연결 성공 로그 출력 확인)  
- OptionalAuthChannelInterceptor 컴파일 및 런타임 검증 완료 (불필요한 필드 참조 오류 없음)

<br/>

## ⚠️ 참고사항
- setAllowedOrigins()는 Credentials 허용 시 유일한 옵션으로 유지 필요  
- 향후 추가 서브도메인 접속이 예상될 경우 origin whitelist 갱신 필요  

<br/>

## 👥 리뷰어 지정
@ggj0228  @AstroJini  

<br/>

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.  
- [x] 코드에 대한 테스트를 진행 하였으며, 결과에 대한 자료를 첨부하였습니다.  
- [x] 최소 2명의 리뷰어를 지정했습니다.  
