### PR TITLE
[Hotfix] candle데이터 스케쥴러 로직 수정 #175

### DIFF
--- a/marketdata/src/main/java/com/beyond/MKX/domain/chart/scheduler/CandleConfirmationScheduler.java
+++ b/marketdata/src/main/java/com/beyond/MKX/domain/chart/scheduler/CandleConfirmationScheduler.java
@@ -242,30 +242,21 @@ public class CandleConfirmationScheduler {
 
     /**
      * 활성 종목 수집
+     * 
+     * Redis 키 구조를 신뢰하고 간단하게 추출
+     * 잘못된 데이터는 애초에 Redis에 넣지 않는 것이 원칙
      */
     private void updateTrackedTickers() {
         try {
             Set<String> tickers = new HashSet<>();
-            int filteredCount = 0;
-            
-            // ✅ 기본 종목 세트 추가 (테스트/개발용)
-            String defaultTickers = "MKX001,MKX002,MKX003,MKX004,MKX005,MKX006,MKX007,MKX008,MKX009,MKX010";
-            tickers.addAll(Arrays.asList(defaultTickers.split(",")));
-            log.info("[CANDLE/CONFIRM] Added default tickers: {}", defaultTickers);
-            
-            // ✅ 개선: Redis에서 활성 종목 추가 수집 (유효성 검증 포함)
+
+            // Redis에서 활성 종목 수집 (검증 없이 그냥 추가)
             Set<String> candleKeys = redisTemplate.keys("candle:*:*");
             if (candleKeys != null) {
                 for (String key : candleKeys) {
                     String[] parts = key.split(":");
-                    if (parts.length >= 2) {
-                        String ticker = parts[1];
-                        if (isValidTicker(ticker)) {
-                            tickers.add(ticker);
-                        } else {
-                            filteredCount++;
-                            log.debug("[CANDLE/CONFIRM] Filtered invalid ticker from candle key: {}", ticker);
-                        }
+                    if (parts.length >= 2 && parts[1] != null && !parts[1].isEmpty()) {
+                        tickers.add(parts[1]);
                     }
                 }
             }
@@ -274,11 +265,8 @@ public class CandleConfirmationScheduler {
             if (orderBookKeys != null) {
                 for (String key : orderBookKeys) {
                     String ticker = key.substring("orderbook:".length());
-                    if (isValidTicker(ticker)) {
+                    if (ticker != null && !ticker.isEmpty()) {
                         tickers.add(ticker);
-                    } else {
-                        filteredCount++;
-                        log.debug("[CANDLE/CONFIRM] Filtered invalid ticker from orderbook key: {}", ticker);
                     }
                 }
             }
@@ -287,11 +275,8 @@ public class CandleConfirmationScheduler {
             if (priceKeys != null) {
                 for (String key : priceKeys) {
                     String ticker = key.substring("price:".length());
-                    if (isValidTicker(ticker)) {
+                    if (ticker != null && !ticker.isEmpty()) {
                         tickers.add(ticker);
-                    } else {
-                        filteredCount++;
-                        log.debug("[CANDLE/CONFIRM] Filtered invalid ticker from price key: {}", ticker);
                     }
                 }
             }
@@ -299,42 +284,12 @@ public class CandleConfirmationScheduler {
             trackedTickers.clear();
             trackedTickers.addAll(tickers);
             
-            log.info("[CANDLE/CONFIRM] Total tracked tickers: {} (filtered: {}) - {}", 
-                    trackedTickers.size(), filteredCount, trackedTickers);
+            log.info("[CANDLE/CONFIRM] Total tracked tickers: {} - {}", 
+                    trackedTickers.size(), trackedTickers);
             
         } catch (Exception e) {
             log.error("[CANDLE/CONFIRM] Failed to update tickers", e);
         }
     }
-    
-    /**
-     * ✅ Ticker 유효성 검증
-     * 
-     * 잘못된 ticker 데이터로 인한 CPU 과부하 방지
-     * - prev_로 시작하는 메타데이터 키 제외
-     * - 콜론(:)이 포함된 비정상 ticker 제외
-     * - 정상적인 ticker 패턴만 허용 (영대문자+숫자)
-     * 
-     * @param ticker 검증할 ticker
-     * @return 유효하면 true
-     */
-    private boolean isValidTicker(String ticker) {
-        if (ticker == null || ticker.isEmpty()) {
-            return false;
-        }
-        
-        // prev_로 시작하는 메타데이터 키 제외
-        if (ticker.startsWith("prev_")) {
-            return false;
-        }
-        
-        // 콜론이 포함된 비정상 ticker 제외 (예: "prev_close:DEPL03")
-        if (ticker.contains(":")) {
-            return false;
-        }
-        
-        // 정상적인 ticker 패턴 (대문자+숫자 조합, 3~10자리)
-        // 예: DEPL04, MKX001, AAPL, GOOGL
-        return ticker.matches("^[A-Z][A-Z0-9]{2,9}$");
-    }
+
 }

--- a/marketdata/src/main/java/com/beyond/MKX/domain/chart/scheduler/CandleConfirmationScheduler.java
+++ b/marketdata/src/main/java/com/beyond/MKX/domain/chart/scheduler/CandleConfirmationScheduler.java
@@ -242,21 +242,30 @@ public class CandleConfirmationScheduler {
 
     /**
      * 활성 종목 수집
-     * 
-     * Redis 키 구조를 신뢰하고 간단하게 추출
-     * 잘못된 데이터는 애초에 Redis에 넣지 않는 것이 원칙
      */
     private void updateTrackedTickers() {
         try {
             Set<String> tickers = new HashSet<>();
-
-            // Redis에서 활성 종목 수집 (검증 없이 그냥 추가)
+            int filteredCount = 0;
+            
+            // ✅ 기본 종목 세트 추가 (테스트/개발용)
+            String defaultTickers = "MKX001,MKX002,MKX003,MKX004,MKX005,MKX006,MKX007,MKX008,MKX009,MKX010";
+            tickers.addAll(Arrays.asList(defaultTickers.split(",")));
+            log.info("[CANDLE/CONFIRM] Added default tickers: {}", defaultTickers);
+            
+            // ✅ 개선: Redis에서 활성 종목 추가 수집 (유효성 검증 포함)
             Set<String> candleKeys = redisTemplate.keys("candle:*:*");
             if (candleKeys != null) {
                 for (String key : candleKeys) {
                     String[] parts = key.split(":");
-                    if (parts.length >= 2 && parts[1] != null && !parts[1].isEmpty()) {
-                        tickers.add(parts[1]);
+                    if (parts.length >= 2) {
+                        String ticker = parts[1];
+                        if (isValidTicker(ticker)) {
+                            tickers.add(ticker);
+                        } else {
+                            filteredCount++;
+                            log.debug("[CANDLE/CONFIRM] Filtered invalid ticker from candle key: {}", ticker);
+                        }
                     }
                 }
             }
@@ -265,8 +274,11 @@ public class CandleConfirmationScheduler {
             if (orderBookKeys != null) {
                 for (String key : orderBookKeys) {
                     String ticker = key.substring("orderbook:".length());
-                    if (ticker != null && !ticker.isEmpty()) {
+                    if (isValidTicker(ticker)) {
                         tickers.add(ticker);
+                    } else {
+                        filteredCount++;
+                        log.debug("[CANDLE/CONFIRM] Filtered invalid ticker from orderbook key: {}", ticker);
                     }
                 }
             }
@@ -275,8 +287,11 @@ public class CandleConfirmationScheduler {
             if (priceKeys != null) {
                 for (String key : priceKeys) {
                     String ticker = key.substring("price:".length());
-                    if (ticker != null && !ticker.isEmpty()) {
+                    if (isValidTicker(ticker)) {
                         tickers.add(ticker);
+                    } else {
+                        filteredCount++;
+                        log.debug("[CANDLE/CONFIRM] Filtered invalid ticker from price key: {}", ticker);
                     }
                 }
             }
@@ -284,12 +299,42 @@ public class CandleConfirmationScheduler {
             trackedTickers.clear();
             trackedTickers.addAll(tickers);
             
-            log.info("[CANDLE/CONFIRM] Total tracked tickers: {} - {}", 
-                    trackedTickers.size(), trackedTickers);
+            log.info("[CANDLE/CONFIRM] Total tracked tickers: {} (filtered: {}) - {}", 
+                    trackedTickers.size(), filteredCount, trackedTickers);
             
         } catch (Exception e) {
             log.error("[CANDLE/CONFIRM] Failed to update tickers", e);
         }
     }
-
+    
+    /**
+     * ✅ Ticker 유효성 검증
+     * 
+     * 잘못된 ticker 데이터로 인한 CPU 과부하 방지
+     * - prev_로 시작하는 메타데이터 키 제외
+     * - 콜론(:)이 포함된 비정상 ticker 제외
+     * - 정상적인 ticker 패턴만 허용 (영대문자+숫자)
+     * 
+     * @param ticker 검증할 ticker
+     * @return 유효하면 true
+     */
+    private boolean isValidTicker(String ticker) {
+        if (ticker == null || ticker.isEmpty()) {
+            return false;
+        }
+        
+        // prev_로 시작하는 메타데이터 키 제외
+        if (ticker.startsWith("prev_")) {
+            return false;
+        }
+        
+        // 콜론이 포함된 비정상 ticker 제외 (예: "prev_close:DEPL03")
+        if (ticker.contains(":")) {
+            return false;
+        }
+        
+        // 정상적인 ticker 패턴 (대문자+숫자 조합, 3~10자리)
+        // 예: DEPL04, MKX001, AAPL, GOOGL
+        return ticker.matches("^[A-Z][A-Z0-9]{2,9}$");
+    }
 }

--- a/marketdata/src/main/java/com/beyond/MKX/domain/chart/scheduler/CandleConfirmationScheduler.java
+++ b/marketdata/src/main/java/com/beyond/MKX/domain/chart/scheduler/CandleConfirmationScheduler.java
@@ -247,12 +247,12 @@ public class CandleConfirmationScheduler {
         try {
             Set<String> tickers = new HashSet<>();
             int filteredCount = 0;
-            
+
             // ✅ 기본 종목 세트 추가 (테스트/개발용)
             String defaultTickers = "MKX001,MKX002,MKX003,MKX004,MKX005,MKX006,MKX007,MKX008,MKX009,MKX010";
             tickers.addAll(Arrays.asList(defaultTickers.split(",")));
             log.info("[CANDLE/CONFIRM] Added default tickers: {}", defaultTickers);
-            
+
             // ✅ 개선: Redis에서 활성 종목 추가 수집 (유효성 검증 포함)
             Set<String> candleKeys = redisTemplate.keys("candle:*:*");
             if (candleKeys != null) {
@@ -313,7 +313,11 @@ public class CandleConfirmationScheduler {
      * 잘못된 ticker 데이터로 인한 CPU 과부하 방지
      * - prev_로 시작하는 메타데이터 키 제외
      * - 콜론(:)이 포함된 비정상 ticker 제외
-     * - 정상적인 ticker 패턴만 허용 (영대문자+숫자)
+     * - 정상적인 ticker 패턴만 허용
+     * 
+     * 허용 패턴:
+     * 1. 대문자로 시작하는 ticker: MKX001, AAPL, GOOGL, DEPL04
+     * 2. 순수 숫자 ticker: 770391, 005930, 123456 (한국 주식 종목코드 등)
      * 
      * @param ticker 검증할 ticker
      * @return 유효하면 true
@@ -333,8 +337,14 @@ public class CandleConfirmationScheduler {
             return false;
         }
         
-        // 정상적인 ticker 패턴 (대문자+숫자 조합, 3~10자리)
+        // ✅ 패턴 1: 대문자로 시작하는 ticker (3~10자리)
         // 예: DEPL04, MKX001, AAPL, GOOGL
-        return ticker.matches("^[A-Z][A-Z0-9]{2,9}$");
+        boolean isAlphaNumeric = ticker.matches("^[A-Z][A-Z0-9]{2,9}$");
+        
+        // ✅ 패턴 2: 순수 숫자 ticker (3~10자리)
+        // 예: 770391, 005930 (한국 주식 종목코드), 123456
+        boolean isPureNumeric = ticker.matches("^[0-9]{3,10}$");
+        
+        return isAlphaNumeric || isPureNumeric;
     }
 }


### PR DESCRIPTION
- redis hash 값을 가져오면서 발생 가능한 종가를 ticker값으로 오해하지 않기 위한 방어 로직으로 인해 순수 숫자로 이루어진 ticker값은 저장 안하게끔 설정하였습니다.
- 이 로직 삭제 하고 기존에 mkx001과 같은 테스트용 ticker 자동 구독하는 로직도 삭제하였습니다.

## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
ticker 유효성 검증 삭제
테스트용 ticker mkx001과 같은 티커값들 자동 구독 로직 삭제
<br/>

## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  

<br/>

## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  

<br/>

## 🧪 테스트 결과
<!-- 코드 검증 시 진행한 테스트 결과에 대한 캡쳐 이미지나 영상 혹은 기타 자료를 첨부해주세요. -->
<!-- 어떤 방식으로 테스트를 진행 하였으며, 왜 그 방식을 채택 했는지에 대한 설명도 작성해주세요. -->
<!-- 성능 테스트 방식이 잘못 되었거나 누락 되어있다면 PR은 거절됩니다. -->

<br/>

## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  

<br/>

## 👥 리뷰어 지정
<!-- 반드시 2명 이상 리뷰어를 지정해주세요 -->
<!-- 모든 리뷰어가 PR 리뷰를 마친 뒤 병합을 진행합니다. -->
<!-- 예: @username1 @username2 -->

<br/>

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: Feat: 테이블 등록 기능 구현 -->
- [ ] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.
- [ ] 코드에 대한 테스트를 진행 하였으며, 결과에 대한 자료를 첨부하였습니다.
- [ ] 최소 2명의 리뷰어를 지정했습니다.