### PR TITLE
[Fix] 티커 검증 로직 수정 (#178)

### DIFF
--- a/marketdata/src/main/java/com/beyond/MKX/domain/chart/scheduler/CandleConfirmationScheduler.java
+++ b/marketdata/src/main/java/com/beyond/MKX/domain/chart/scheduler/CandleConfirmationScheduler.java
@@ -18,12 +18,12 @@ import java.util.*;
 
 /**
  * ✅ 개선된 캔들 확정 스케줄러
- * 
+ *
  * 핵심 개선사항:
  * 1. Redis가 아닌 InfluxDB 체결 데이터로 캔들 재계산
  * 2. 데이터 정합성 보장 (Source of Truth = 체결 데이터)
  * 3. Redis 유실 시에도 복구 가능
- * 
+ *
  * 동작 방식:
  * - 각 interval 종료 시 해당 기간의 체결 데이터 조회
  * - 체결 데이터로부터 OHLCV 재계산
@@ -116,87 +116,87 @@ public class CandleConfirmationScheduler {
 
     /**
      * ✅ 개선된 캔들 확정 프로세스
-     * 
+     *
      * 1. 이전 캔들 확정 (InfluxDB 체결 데이터 기반)
      * 2. 현재 캔들 임시 생성 (거래 없어도 생성)
      */
     private void confirmCandles(String interval, long intervalMinutes) {
         try {
             log.info("[CANDLE/CONFIRM] ========== Starting: interval={} ==========", interval);
-            
+
             Instant now = Instant.now();
             Instant previousCandleTime = calculatePreviousCandleTime(now, intervalMinutes);
             Instant currentCandleTime = calculateCurrentCandleTime(now, intervalMinutes);
-            
-            log.info("[CANDLE/CONFIRM] Previous candle: {}, Current candle: {}, interval={}", 
+
+            log.info("[CANDLE/CONFIRM] Previous candle: {}, Current candle: {}, interval={}",
                     previousCandleTime, currentCandleTime, interval);
-            
+
             updateTrackedTickers();
-            
+
             if (trackedTickers.isEmpty()) {
                 log.warn("[CANDLE/CONFIRM] No tickers found");
                 return;
             }
-            
+
             log.info("[CANDLE/CONFIRM] Processing {} tickers", trackedTickers.size());
-            
+
             int previousConfirmed = 0;
             int previousEmpty = 0;
             int currentConfirmed = 0;
             int currentEmpty = 0;
             int failedCount = 0;
-            
+
             for (String ticker : trackedTickers) {
                 try {
                     // 1️⃣ 이전 캔들 확정 (체결 데이터 기반)
                     Candle previousCandle = chartService.recalculateCandleFromExecutions(
                             ticker, interval, previousCandleTime);
-                    
+
                     if (previousCandle != null) {
                         if (previousCandle.getVolume() != null && previousCandle.getVolume().compareTo(BigDecimal.ZERO) > 0) {
                             previousConfirmed++;
-                            log.info("[CANDLE/CONFIRM] ✅ Previous confirmed: ticker={}, time={}, O={}, H={}, L={}, C={}, V={}", 
-                                    ticker, previousCandleTime, previousCandle.getOpen(), previousCandle.getHigh(), 
+                            log.info("[CANDLE/CONFIRM] ✅ Previous confirmed: ticker={}, time={}, O={}, H={}, L={}, C={}, V={}",
+                                    ticker, previousCandleTime, previousCandle.getOpen(), previousCandle.getHigh(),
                                     previousCandle.getLow(), previousCandle.getClose(), previousCandle.getVolume());
                         } else {
                             previousEmpty++;
-                            log.debug("[CANDLE/CONFIRM] 📊 Previous empty: ticker={}, time={}, close={}", 
+                            log.debug("[CANDLE/CONFIRM] 📊 Previous empty: ticker={}, time={}, close={}",
                                     ticker, previousCandleTime, previousCandle.getClose());
                         }
                         // ✅ ChartService에서 이미 publishCandle() 호출하므로 여기서 중복 발행 불필요
                     }
-                    
+
                     // 2️⃣ 현재 캔들 임시 생성 (항상 생성 시도)
                     Candle currentCandle = chartService.recalculateCandleFromExecutions(
                             ticker, interval, currentCandleTime);
-                    
+
                     if (currentCandle != null) {
                         if (currentCandle.getVolume() != null && currentCandle.getVolume().compareTo(BigDecimal.ZERO) > 0) {
                             currentConfirmed++;
-                            log.info("[CANDLE/CONFIRM] ✅ Current confirmed: ticker={}, time={}, O={}, H={}, L={}, C={}, V={}", 
-                                    ticker, currentCandleTime, currentCandle.getOpen(), currentCandle.getHigh(), 
+                            log.info("[CANDLE/CONFIRM] ✅ Current confirmed: ticker={}, time={}, O={}, H={}, L={}, C={}, V={}",
+                                    ticker, currentCandleTime, currentCandle.getOpen(), currentCandle.getHigh(),
                                     currentCandle.getLow(), currentCandle.getClose(), currentCandle.getVolume());
                         } else {
                             currentEmpty++;
-                            log.debug("[CANDLE/CONFIRM] 📊 Current empty: ticker={}, time={}, close={}", 
+                            log.debug("[CANDLE/CONFIRM] 📊 Current empty: ticker={}, time={}, close={}",
                                     ticker, currentCandleTime, currentCandle.getClose());
                         }
                         // ✅ ChartService에서 이미 publishCandle() 호출하므로 여기서 중복 발행 불필요
                     } else {
                         log.debug("[CANDLE/CONFIRM] ⏭️ Skipped: ticker={} (no base price)", ticker);
                     }
-                    
+
                 } catch (Exception e) {
                     failedCount++;
                     log.error("[CANDLE/CONFIRM] ❌ Failed: ticker={}", ticker, e);
                 }
             }
-            
+
             log.info("[CANDLE/CONFIRM] ========== Completed: interval={} ==========", interval);
             log.info("[CANDLE/CONFIRM] Previous - confirmed={}, empty={}", previousConfirmed, previousEmpty);
             log.info("[CANDLE/CONFIRM] Current - confirmed={}, empty={}", currentConfirmed, currentEmpty);
             log.info("[CANDLE/CONFIRM] Failed={}", failedCount);
-            
+
         } catch (Exception e) {
             log.error("[CANDLE/CONFIRM] ❌ Failed: interval={}", interval, e);
         }
@@ -204,7 +204,7 @@ public class CandleConfirmationScheduler {
 
     /**
      * 직전 캔들 시작 시각 계산
-     * 
+     *
      * 예: 현재 14:30:00 → 14:29:00 반환 (1분봉)
      */
     private Instant calculatePreviousCandleTime(Instant now, long intervalMinutes) {
@@ -214,17 +214,17 @@ public class CandleConfirmationScheduler {
                     .truncatedTo(ChronoUnit.DAYS)
                     .toInstant();
         }
-        
+
         long epochMinutes = now.getEpochSecond() / 60;
         long currentIntervalStart = (epochMinutes / intervalMinutes) * intervalMinutes;
         long previousIntervalStart = currentIntervalStart - intervalMinutes;
-        
+
         return Instant.ofEpochSecond(previousIntervalStart * 60);
     }
 
     /**
      * 현재 캔들 시작 시각 계산
-     * 
+     *
      * 예: 현재 14:30:00 → 14:30:00 반환 (1분봉)
      */
     private Instant calculateCurrentCandleTime(Instant now, long intervalMinutes) {
@@ -233,10 +233,10 @@ public class CandleConfirmationScheduler {
                     .truncatedTo(ChronoUnit.DAYS)
                     .toInstant();
         }
-        
+
         long epochMinutes = now.getEpochSecond() / 60;
         long currentIntervalStart = (epochMinutes / intervalMinutes) * intervalMinutes;
-        
+
         return Instant.ofEpochSecond(currentIntervalStart * 60);
     }
 
@@ -247,12 +247,7 @@ public class CandleConfirmationScheduler {
         try {
             Set<String> tickers = new HashSet<>();
             int filteredCount = 0;
-            
-            // ✅ 기본 종목 세트 추가 (테스트/개발용)
-            String defaultTickers = "MKX001,MKX002,MKX003,MKX004,MKX005,MKX006,MKX007,MKX008,MKX009,MKX010";
-            tickers.addAll(Arrays.asList(defaultTickers.split(",")));
-            log.info("[CANDLE/CONFIRM] Added default tickers: {}", defaultTickers);
-            
+
             // ✅ 개선: Redis에서 활성 종목 추가 수집 (유효성 검증 포함)
             Set<String> candleKeys = redisTemplate.keys("candle:*:*");
             if (candleKeys != null) {
@@ -269,7 +264,7 @@ public class CandleConfirmationScheduler {
                     }
                 }
             }
-            
+
             Set<String> orderBookKeys = redisTemplate.keys("orderbook:*");
             if (orderBookKeys != null) {
                 for (String key : orderBookKeys) {
@@ -282,7 +277,7 @@ public class CandleConfirmationScheduler {
                     }
                 }
             }
-            
+
             Set<String> priceKeys = redisTemplate.keys("price:*");
             if (priceKeys != null) {
                 for (String key : priceKeys) {
@@ -295,26 +290,26 @@ public class CandleConfirmationScheduler {
                     }
                 }
             }
-            
+
             trackedTickers.clear();
             trackedTickers.addAll(tickers);
-            
-            log.info("[CANDLE/CONFIRM] Total tracked tickers: {} (filtered: {}) - {}", 
+
+            log.info("[CANDLE/CONFIRM] Total tracked tickers: {} (filtered: {}) - {}",
                     trackedTickers.size(), filteredCount, trackedTickers);
-            
+
         } catch (Exception e) {
             log.error("[CANDLE/CONFIRM] Failed to update tickers", e);
         }
     }
-    
+
     /**
      * ✅ Ticker 유효성 검증
-     * 
+     *
      * 잘못된 ticker 데이터로 인한 CPU 과부하 방지
      * - prev_로 시작하는 메타데이터 키 제외
      * - 콜론(:)이 포함된 비정상 ticker 제외
      * - 정상적인 ticker 패턴만 허용 (영대문자+숫자)
-     * 
+     *
      * @param ticker 검증할 ticker
      * @return 유효하면 true
      */
@@ -322,19 +317,20 @@ public class CandleConfirmationScheduler {
         if (ticker == null || ticker.isEmpty()) {
             return false;
         }
-        
+
         // prev_로 시작하는 메타데이터 키 제외
         if (ticker.startsWith("prev_")) {
             return false;
         }
-        
+
         // 콜론이 포함된 비정상 ticker 제외 (예: "prev_close:DEPL03")
         if (ticker.contains(":")) {
             return false;
         }
-        
-        // 정상적인 ticker 패턴 (대문자+숫자 조합, 3~10자리)
-        // 예: DEPL04, MKX001, AAPL, GOOGL
-        return ticker.matches("^[A-Z][A-Z0-9]{2,9}$");
+
+        // 정상적인 ticker 패턴 (숫자 조합, 6자리)
+        // "^\\d{6}$" 정규식은 6자리 숫자인지 검증함.
+        // 예) 652634
+        return ticker.matches("^\\d{6}$");
     }
 }


### PR DESCRIPTION
- 티커 검증 정규식을 기존 "^[A-Z][Z-Z0-9]{2,9}$"에서 "^\\d{6}$"로 수정하였음.
- 기존에는 무조건 대문자와 숫자로 구성된 티커만 마켓데이터 tsdb에 저장되게 설정되어 있었지만, 이를 6자리 숫자인지만 검증하게 하여 우리 시스템 설계에 맞게 수정하였음.